### PR TITLE
Support Livewire 4 alongside 3.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         php: ['8.2', '8.3', '8.4']
         laravel: ['11.*', '12.*']
-    name: PHP ${{ matrix.php }} · Laravel ${{ matrix.laravel }}
+        livewire: ['3.*', '4.*']
+    name: PHP ${{ matrix.php }} · Laravel ${{ matrix.laravel }} · Livewire ${{ matrix.livewire }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "livewire/livewire:${{ matrix.livewire }}" --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Driver-agnostic capture of queue jobs (full `queued → running → done/failed`
   lifecycle), artisan commands, and scheduled tasks.
 - Standalone Livewire dashboard: overview, runs, run detail, failures,
-  dispatcher, command runner, schedule and workload pages.
+  dispatcher, command runner, schedule and workload pages. Compatible with both
+  Livewire 3.5+ and Livewire 4 (class-based components; no rewrite required).
 - Manual control: dispatch allowlisted jobs (typed form reflected from the
   constructor) and run allowlisted artisan commands, with an audit log.
 - Failure grouping with Sentry-style fingerprints and a `FailureRecorded` event

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ response is sent. Enable with `VIGILANCE_TRACING=true`; see
 
 - PHP 8.2+
 - Laravel 11, 12 or 13
-- Livewire 3.5+ (pulled in automatically)
+- Livewire 3.5+ or 4 (pulled in automatically)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/database": "^11.0 || ^12.0 || ^13.0",
         "illuminate/queue": "^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^11.0 || ^12.0 || ^13.0",
-        "livewire/livewire": "^3.5",
+        "livewire/livewire": "^3.5 || ^4.0",
         "symfony/process": "^6.4 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
## What

Widen the `livewire/livewire` constraint from `^3.5` to `^3.5 || ^4.0` so apps already on **Livewire 4** can install Vigilance. The previous constraint (`>=3.5 <4.0`) silently excluded every v4 consumer.

## Why no rewrite

Vigilance uses the class-based component API (`extends Livewire\Component`, `Livewire::component()` registration, full-page `Route::get('/', Component::class)`, `@livewireStyles`/`@livewireScripts` layout) — all of which Livewire 4 supports unchanged. Single-file components in v4 are opt-in, not required.

## Changes

- **composer.json** — `"livewire/livewire": "^3.5 || ^4.0"`
- **CI** — added a `livewire: ['3.*', '4.*']` matrix dimension (12 legs). No exclusions needed: v4.3.1 requires only `php ^8.1` + `illuminate ^10–^13`, broader than Vigilance''s own floor.
- **README / CHANGELOG** — note dual v3.5+/v4 compatibility.

## Verification (local, against Livewire v4.3.1)

- ✅ 146 tests passed (598 assertions), including all full-page Livewire component tests
- ✅ PHPStan: no errors
- ✅ `composer validate`: valid

Zero changes to the 18 components.