### PR TITLE
Fix/duplicate boot calls in octane

### DIFF
--- a/src/Capture/JobCapture.php
+++ b/src/Capture/JobCapture.php
@@ -10,16 +10,23 @@ use Illuminate\Support\Facades\Queue;
 
 class JobCapture
 {
+    /** Prevents Queue::createPayloadUsing() accumulating in the static callback array when the app boots twice (e.g. Vapor's Octane runtime). */
+    private static bool $payloadCallbackRegistered = false;
+
     public function __construct(protected Recorder $recorder) {}
 
     public function register(): void
     {
-        // The correlation trick: a uuid lives inside the payload, so a job can
-        // be tracked from "queued" through "processed/failed" across ANY queue
-        // driver (sync, database, redis, sqs, beanstalkd).
-        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
-            return $this->recorder->onJobPayloadCreate((string) $connection, $queue, $payload);
-        });
+        if (! static::$payloadCallbackRegistered) {
+            static::$payloadCallbackRegistered = true;
+
+            // The correlation trick: a uuid lives inside the payload, so a job can
+            // be tracked from "queued" through "processed/failed" across ANY queue
+            // driver (sync, database, redis, sqs, beanstalkd).
+            Queue::createPayloadUsing(function ($connection, $queue, $payload) {
+                return $this->recorder->onJobPayloadCreate((string) $connection, $queue, $payload);
+            });
+        }
 
         $events = app('events');
 

--- a/src/Capture/JobCapture.php
+++ b/src/Capture/JobCapture.php
@@ -10,15 +10,17 @@ use Illuminate\Support\Facades\Queue;
 
 class JobCapture
 {
-    /** Prevents Queue::createPayloadUsing() accumulating in the static callback array when the app boots twice (e.g. Vapor's Octane runtime). */
+    /**
+     * Prevents Queue::createPayloadUsing() accumulating in the static callback array when the app boots twice (e.g. Vapor's Octane runtime).
+     */
     private static bool $payloadCallbackRegistered = false;
 
     public function __construct(protected Recorder $recorder) {}
 
     public function register(): void
     {
-        if (! static::$payloadCallbackRegistered) {
-            static::$payloadCallbackRegistered = true;
+        if (! self::$payloadCallbackRegistered) {
+            self::$payloadCallbackRegistered = true;
 
             // The correlation trick: a uuid lives inside the payload, so a job can
             // be tracked from "queued" through "processed/failed" across ANY queue

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,10 +4,25 @@ namespace Vigilance\Tests;
 
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use ReflectionProperty;
+use Vigilance\Capture\JobCapture;
 use Vigilance\VigilanceServiceProvider;
 
 class TestCase extends Orchestra
 {
+    protected function setUp(): void
+    {
+        $this->resetCaptureRegistration();
+
+        parent::setUp();
+    }
+
+    private function resetCaptureRegistration(): void
+    {
+        $prop = new ReflectionProperty(JobCapture::class, 'payloadCallbackRegistered');
+        $prop->setValue(null, false);
+    }
+
     /** @return array<int, class-string> */
     protected function getPackageProviders($app): array
     {


### PR DESCRIPTION
<!-- Thanks for contributing to Vigilance! -->

## Context 

Hi, 
Thanks for this package, looks awesome so far!
I was testing it on one of our test environments (Vapor + Octane) and noticed duplicate runs (same UUID) for some jobs. It is only happening specifically with Octane and deployed using Vapor (AWS Lambda).

Have traced the issue, summary and fix below:

## Summary

When deploying with Laravel Octane on Vapor, the application bootstraps twice in the same PHP process. Vapor's runtime runs config:cache before handing off to Octane::boot(), and both operations fully boot the application including all service providers.

Because Queue::$createPayloadCallbacks is a static array shared across the entire process, calling Queue::createPayloadUsing() twice appends two callbacks. Every job dispatch then fires onJobPayloadCreate() twice, creating two Queued records with the same UUID. Only the second one gets updated to Running/Succeeded, leaving a ghost Queued record permanently.


**Fix:** 
Added a static flag to JobCapture so Queue::createPayloadUsing() is only run once regardless of how many times the service provider boots.

I tested the fix locally (frankenphp / Octane) and on one of our own test environment (Vapor + Octane)


## Checklist

- [x] Tests added/updated and `composer test` passes
- [x] `composer lint` (Pint) passes
- [x] `composer analyse` (PHPStan level 5) passes
- [ ] Dashboard changes verified with no accessibility regressions (axe)
- [ ] `CHANGELOG.md` updated under "Unreleased"
- [x] Production-safety considered (no added request latency, capture is guarded)
