### PR TITLE
Per-queue pause + queue clear/cancel, with full MCP control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-23
+
+### Added
+- **Per-queue pause — stop draining one queue while the rest keep running.**
+  The supervisor now honours a per-queue pause flag: it narrows each pool to its
+  still-active queues (a `balance=false` pool serving several queues is relaunched
+  bound to only its unpaused ones) and holds a fully-paused pool at zero workers
+  without ever spinning workers up just to tear them down. Pauses can be timed
+  (auto-resume after N seconds) or indefinite, are delivered through the same
+  cache-flag channel as the global pause (so they work on every driver and OS),
+  and deliberately survive a supervisor restart or deploy until resumed or lapsed.
+  Drive it from the **Workload** page (Pause / 15m / 1h / Resume per queue, plus a
+  strip listing paused-but-idle queues), or from the CLI:
+  `vigilance:pause --queue=emails [--connection=redis] [--for=900]` and
+  `vigilance:continue --queue=emails`. `vigilance:status` lists paused queues and
+  their expiry. Pausing is an operational lever and is always available.
+- **Clear a queue from the dashboard.** A driver-agnostic purge (database, redis, sqs
+  — anything implementing `ClearableQueue`; beanstalkd is not supported) exposed as a **Clear**
+  button per queue on the Workload page.
+- **Cancel individual pending jobs.** Select waiting jobs on the **Pending** page
+  (database driver) and cancel them by id.
+  Both destructive operations require the manual-control master switch
+  (`VIGILANCE_CONTROL_ENABLED=true`), are guarded behind a confirm dialog, and are
+  written to the same audit log as every other manual action.
+- **Full worker & queue control over MCP.** Five new MCP tools let an AI agent
+  drive the control plane against live data, not just read it: `control-workers`
+  (pause / resume / restart / terminate the fleet), `pause-queue` / `resume-queue`
+  (single queue, optionally timed), `clear-queue` (purge a backlog on
+  database/redis/sqs) and `cancel-pending` (delete waiting jobs by id, database
+  driver). All self-gate
+  on `VIGILANCE_MCP_ALLOW_WRITES`; the two destructive ones additionally require
+  `VIGILANCE_CONTROL_ENABLED` — and every call is audited. The read tools now
+  surface the state to act on: `workers` reports the global control status and
+  `queues` flags each paused queue plus lists their auto-resume expiry.
+
 ### Fixed
 - **Duplicate "queued" job runs under Laravel Octane on Vapor.** Vapor's Octane
   runtime boots the application twice in the same PHP process (once for
@@ -15,6 +50,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   one of which was ever advanced to `Running`/`Succeeded`, leaving a permanent
   ghost row. Registration is now guarded so the hook is installed once per
   process regardless of how many times the service provider boots.
+- **Static analysis stayed clean against newer Larastan.** The APM aggregate
+  SQL builder used inline `match` expressions whose default arm a newer Larastan
+  proved unreachable (`match.alwaysTrue`) while older versions required it — an
+  irreconcilable pair for the floating dev toolchain. The two branches are now
+  extracted into `tailAggregate()` / `bucketAggregate()` helpers that take a
+  plain `string`, so the default stays reachable and analysis is version-stable.
+  No behavioural change.
 
 ## [0.6.1] - 2026-06-26
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,13 @@ The tool set mirrors **every dashboard page**, so the agent can reach anything y
 | Front-end (RUM) | `vitals` |
 | Tracing & logs | `traces` · `trace` · `logs` |
 | Reliability | `slos` · `incidents` · `releases` |
-| Queues & workers | `workers` · `queues` · `pending` · `schedule` · `batches` · `tags` |
+| Queues & workers | `workers` (+ control status) · `queues` (+ paused state) · `pending` · `schedule` · `batches` · `tags` |
 | Business metrics | `custom-metrics` |
 | **Writes** (opt-in) | `resolve-issue` · `acknowledge-issue` · `mute-issue` · `reopen-issue` · `retry-run` · `retry-issue` |
+| **Worker & queue control** (opt-in) | `control-workers` · `pause-queue` · `resume-queue` · `clear-queue` · `cancel-pending` |
 | **Manual control** (opt-in, double-gated) | `dispatchable-jobs` · `runnable-commands` · `dispatch-job` · `run-command` |
 
-The **manual-control** tools (dispatch a job / run an artisan command) require **both** `VIGILANCE_MCP_ALLOW_WRITES=true` **and** the dashboard's own `VIGILANCE_CONTROL_ENABLED=true`, and obey the same `control` allowlist — so they're off unless you deliberately opt in twice.
+The **worker & queue control** tools let the agent run the control plane, not just observe it: `control-workers` pauses / resumes / restarts / terminates the fleet, and `pause-queue` / `resume-queue` toggle a single queue (optionally timed). These need `VIGILANCE_MCP_ALLOW_WRITES=true`. The destructive `clear-queue` (purge a backlog) and `cancel-pending` (delete waiting jobs by id) — like **manual control** (dispatch a job / run an artisan command) — require **both** `VIGILANCE_MCP_ALLOW_WRITES=true` **and** `VIGILANCE_CONTROL_ENABLED=true`, so they're off unless you deliberately opt in twice. Every write is audited.
 
 This complements the [Laravel Boost](#ai-assisted-development-laravel-boost)
 integration below: **Boost teaches your agent Vigilance's conventions (how to
@@ -395,10 +396,19 @@ If no mail recipient and no Slack webhook is configured, alerting stays silent
 | Command | Purpose |
 |---|---|
 | `vigilance:supervise` | Run & auto-scale your queue workers (replaces `queue:work`). `--once` / `--max-time=N` for bounded/test runs |
-| `vigilance:status` | Show running supervisors and their workers |
-| `vigilance:pause` / `vigilance:continue` | Pause / resume all supervisors |
+| `vigilance:status` | Show running supervisors, their workers, and any paused queues |
+| `vigilance:pause` / `vigilance:continue` | Pause / resume all supervisors — or a single queue with `--queue=` (`--for=SECONDS` for a timed pause, `--connection=`) |
 | `vigilance:restart` | Gracefully restart all workers (e.g. after a deploy) |
 | `vigilance:terminate` | Gracefully stop the supervisor and all its workers |
+
+**Per-queue controls.** Beyond the global pause, you can pause / resume an
+individual queue (indefinitely or for a set duration) while every other queue
+keeps draining — from the CLI above or the **Workload** page. A paused queue
+survives worker restarts and deploys until you resume it or its timer lapses.
+With manual control enabled (`VIGILANCE_CONTROL_ENABLED=true`) you can also
+**clear** a queue's backlog (`database` / `redis` / `sqs`) from the Workload page
+and **cancel** individual pending jobs (database driver) from the Pending page —
+both audited.
 
 **APM heartbeat & uptime**
 

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -266,7 +266,11 @@ return [
     |
     | Tools are READ-ONLY unless you set "allow_writes" => true, which also
     | exposes triage/retry tools (resolve / acknowledge / mute an issue, retry a
-    | failed job). Every write is recorded in the same audit log as the dashboard.
+    | failed job) and worker/queue control (pause / resume / restart / terminate
+    | the fleet, and pause / resume a single queue). Clearing a queue's backlog
+    | and cancelling individual pending jobs additionally require "control.enabled"
+    | (the same manual-control master switch as job dispatch / command running).
+    | Every write is recorded in the same audit log as the dashboard.
     | Output is redacted (using "redact" below) and bounded by the caps here, so a
     | tool can never leak a secret or dump the whole database into the agent.
     |

--- a/docs/index.html
+++ b/docs/index.html
@@ -201,7 +201,7 @@
       <div class="card reveal">
         <div class="card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg></div>
         <h3>Query it from your AI agent</h3>
-        <p>An optional <strong>MCP server</strong> exposes your errors, runs, APM, traces, logs, SLOs and release health to Claude Code, Cursor or Copilot — so the agent can investigate and fix against live data. Read-only and redacted by default; writes are gated and audited.</p>
+        <p>An optional <strong>MCP server</strong> exposes your errors, runs, APM, traces, logs, SLOs and release health to your AI agent — so it can investigate and fix against live data, and even drive the fleet (pause / resume / clear / cancel a queue, restart workers). Read-only and redacted by default; writes are gated and audited.</p>
       </div>
 
     </div>
@@ -256,6 +256,7 @@
         <ul class="checklist" role="list">
           <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m5 13 4 4L19 7"/></svg> <span><strong>Autoscaling</strong> by backlog or time-to-clear, throttled by max-shift &amp; cooldown.</span></li>
           <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m5 13 4 4L19 7"/></svg> <span><strong>Graceful</strong> pause / continue / restart / terminate — even on Windows (cache control-plane + signals).</span></li>
+          <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m5 13 4 4L19 7"/></svg> <span><strong>Per-queue control</strong> — pause a single queue (timed or indefinite) while the rest keep draining, clear a backlog or cancel pending jobs — from the dashboard, CLI or MCP, all audited.</span></li>
           <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m5 13 4 4L19 7"/></svg> <span><strong>Crash recovery</strong> — dead workers respawn; a live Workers dashboard shows pools &amp; heartbeats.</span></li>
         </ul>
         <div class="pills">
@@ -452,8 +453,8 @@ Gate::<span class="tok-f">define</span>(<span class="tok-s">'viewVigilance'</spa
       <div class="cmd-group">
         <h3>Worker supervision</h3>
         <div class="cmd"><code>vigilance:supervise</code><span>Run &amp; auto-scale your queue workers (replaces <code class="inline">queue:work</code>)</span></div>
-        <div class="cmd"><code>vigilance:status</code><span>Show running supervisors and their workers</span></div>
-        <div class="cmd"><code>vigilance:pause / continue</code><span>Pause / resume all supervisors</span></div>
+        <div class="cmd"><code>vigilance:status</code><span>Show running supervisors, their workers and any paused queues</span></div>
+        <div class="cmd"><code>vigilance:pause / continue</code><span>Pause / resume all supervisors — or a single queue with <code class="inline">--queue=</code> (<code class="inline">--for=</code> for a timed pause)</span></div>
         <div class="cmd"><code>vigilance:restart</code><span>Gracefully restart all workers (e.g. after a deploy)</span></div>
         <div class="cmd"><code>vigilance:terminate</code><span>Gracefully stop the supervisor and its workers</span></div>
       </div>

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -123,6 +123,24 @@ to `mcp` (or `mcp:<user>` over an authenticated web transport) — exactly like 
 manual action taken from the dashboard. Retries re-dispatch the original job via
 the same path as the dashboard's retry, so lineage and capture are preserved.
 
+### Worker & queue control (opt-in)
+
+Also disabled until `VIGILANCE_MCP_ALLOW_WRITES=true`. These drive the same
+control plane as `vigilance:pause` / `continue` / `restart` and the Workload page,
+so the agent can act on what `workers` / `queues` report (both now surface the
+control status and per-queue paused state).
+
+| Tool | Purpose |
+|---|---|
+| `control-workers` | Pause / resume / restart / terminate every supervisor (global). Needs `allow_writes`. |
+| `pause-queue` | Pause a single queue — indefinitely or for N seconds — while the others keep draining. Needs `allow_writes`. |
+| `resume-queue` | Resume a single paused queue. Needs `allow_writes`. |
+| `clear-queue` | Purge a whole queue's backlog (database / redis / sqs; beanstalkd/sync unsupported). Destructive — needs `allow_writes` **and** `control.enabled`. |
+| `cancel-pending` | Delete specific waiting jobs by id (database driver; discover ids with `pending`). Destructive — needs `allow_writes` **and** `control.enabled`. |
+
+Per-queue pauses survive a worker restart or deploy until resumed or their timer
+lapses. Every call is recorded in the audit log.
+
 ### Manual control (opt-in, double-gated)
 
 Dispatching jobs and running artisan commands is **off** unless you enable **both**

--- a/resources/views/pages/pending.blade.php
+++ b/resources/views/pages/pending.blade.php
@@ -8,10 +8,19 @@
     </div>
 
     @forelse ($groups as $group)
+        @php $canCancel = $controlEnabled && $group['driver'] === 'database' && ! empty($group['jobs']); @endphp
         <div class="v-card overflow-hidden">
             <div class="v-card__header">
-                <h2 class="v-card__title">{{ $group['connection'] }}</h2>
-                <span class="v-pill is-neutral font-mono">{{ $group['driver'] }}</span>
+                <div class="flex items-center gap-2.5">
+                    <h2 class="v-card__title">{{ $group['connection'] }}</h2>
+                    <span class="v-pill is-neutral font-mono">{{ $group['driver'] }}</span>
+                </div>
+                @if ($canCancel)
+                    <button type="button"
+                        wire:click="cancelSelected(@js($group['connection']))"
+                        wire:confirm="Cancel the selected pending job(s)? This deletes them from the queue and cannot be undone."
+                        class="v-btn v-btn--sm v-btn--danger">Cancel selected</button>
+                @endif
             </div>
 
             @if ($group['jobs'] === null)
@@ -23,6 +32,7 @@
                     <table class="v-table v-table--hover">
                         <thead>
                             <tr>
+                                @if ($canCancel)<th scope="col" class="w-8"><span class="sr-only">Select</span></th>@endif
                                 <th scope="col">ID</th>
                                 <th scope="col">Queue</th>
                                 <th scope="col">Job</th>
@@ -33,6 +43,9 @@
                         <tbody>
                             @foreach ($group['jobs'] as $job)
                                 <tr>
+                                    @if ($canCancel)
+                                        <td><input type="checkbox" wire:model="selected" value="{{ $group['connection'].'#'.$job['id'] }}" aria-label="Select job {{ $job['id'] }}"></td>
+                                    @endif
                                     <td class="font-mono v-num">{{ $job['id'] }}</td>
                                     <td class="font-mono">{{ $job['queue'] }}</td>
                                     <td class="font-medium v-strong">{{ class_basename($job['name']) }}</td>

--- a/resources/views/pages/workload.blade.php
+++ b/resources/views/pages/workload.blade.php
@@ -9,6 +9,15 @@
         return number_format($ms / 1000, 2).'s';
     };
     $fmtMem = fn (?int $b) => $b === null ? '—' : number_format($b / 1048576, 1).'MB';
+    $fmtExpiry = function (?int $ts): string {
+        if ($ts === null) {
+            return 'indefinitely';
+        }
+        $mins = (int) ceil(($ts - time()) / 60);
+        return $mins > 0 ? "for ~{$mins} min" : 'briefly';
+    };
+    // Queues shown as cards below (so a paused-but-idle queue can still be listed).
+    $listed = collect($queues)->map(fn ($q) => ($q['connection_name'] ?? '').'|'.$q['queue'])->all();
 @endphp
 
 <div wire:poll.visible.5s class="space-y-6">
@@ -31,11 +40,32 @@
         @endif
     </div>
 
+    @php $orphanPaused = collect($paused)->reject(fn ($e, $key) => in_array($key, $listed, true)); @endphp
+    @if ($orphanPaused->isNotEmpty())
+        <div class="v-card v-card--pad space-y-2">
+            <span class="v-stat__label">Paused queues (no recent activity)</span>
+            <div class="flex flex-wrap gap-2">
+                @foreach ($orphanPaused as $key => $expiresAt)
+                    @php [$conn, $q] = array_pad(explode('|', $key, 2), 2, ''); @endphp
+                    <span class="inline-flex items-center gap-2 v-pill is-paused">
+                        <span class="v-dot"></span>
+                        <span class="font-mono">{{ $q }}</span>
+                        <span class="v-faint">· {{ $conn }} · {{ $fmtExpiry($expiresAt) }}</span>
+                        <button type="button" wire:click="resumeQueue(@js($conn), @js($q))" class="v-btn v-btn--sm">Resume</button>
+                    </span>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
     <p class="text-xs v-muted">Live queue depth is only available for the <code class="v-code">database</code> and <code class="v-code">redis</code> drivers; other drivers show “n/a”.</p>
 
     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         @forelse ($queues as $queue)
             @php
+                $conn = (string) ($queue['connection_name'] ?? '');
+                $qKey = $conn.'|'.$queue['queue'];
+                $isPaused = array_key_exists($qKey, $paused);
                 $series = collect($queue['series'])->map(fn ($p) => (int) ($p->throughput ?? 0))->values();
                 $maxPt = max(1, $series->max() ?? 1);
                 $sw = 240; $sh = 40; $n = max(1, $series->count());
@@ -49,7 +79,12 @@
             @endphp
             <div class="v-card v-card--pad">
                 <div class="flex items-baseline justify-between gap-2">
-                    <h2 class="truncate font-semibold font-mono v-strong">{{ $queue['queue'] }}</h2>
+                    <div class="flex items-center gap-2 min-w-0">
+                        <h2 class="truncate font-semibold font-mono v-strong">{{ $queue['queue'] }}</h2>
+                        @if ($isPaused)
+                            <span class="v-pill is-paused uppercase tracking-wide text-[10px]"><span class="v-dot"></span>paused</span>
+                        @endif
+                    </div>
                     <span class="text-[10px] font-mono v-faint">{{ $queue['connection_name'] ?: 'no connection' }}</span>
                 </div>
 
@@ -87,6 +122,24 @@
                         <line x1="0" y1="{{ $sh - 2 }}" x2="{{ $sw }}" y2="{{ $sh - 2 }}" stroke="rgb(113 113 122 / 0.4)" stroke-dasharray="3 3" />
                     @endif
                 </svg>
+
+                @if ($conn !== '')
+                    <div class="mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
+                        @if ($isPaused)
+                            <button type="button" wire:click="resumeQueue(@js($conn), @js($queue['queue']))" class="v-btn v-btn--primary v-btn--sm">Resume</button>
+                        @else
+                            <button type="button" wire:click="pauseQueue(@js($conn), @js($queue['queue']))" class="v-btn v-btn--sm">Pause</button>
+                            <button type="button" wire:click="pauseQueue(@js($conn), @js($queue['queue']), 15)" class="v-btn v-btn--sm" title="Pause for 15 minutes">15m</button>
+                            <button type="button" wire:click="pauseQueue(@js($conn), @js($queue['queue']), 60)" class="v-btn v-btn--sm" title="Pause for 1 hour">1h</button>
+                        @endif
+                        @if ($controlEnabled)
+                            <button type="button"
+                                wire:click="clearQueue(@js($conn), @js($queue['queue']))"
+                                wire:confirm="Delete ALL pending jobs on [{{ $queue['queue'] }}]? This cannot be undone."
+                                class="v-btn v-btn--sm v-btn--danger ml-auto">Clear</button>
+                        @endif
+                    </div>
+                @endif
             </div>
         @empty
             <div class="md:col-span-2 xl:col-span-3">

--- a/src/Apm/Storage/DatabaseStorage.php
+++ b/src/Apm/Storage/DatabaseStorage.php
@@ -637,14 +637,7 @@ class DatabaseStorage implements Storage
                     $query->select('key_hash');
 
                     foreach ($aggregates as $aggregate) {
-                        $query->selectRaw(match ($aggregate) {
-                            'count' => 'count(*)',
-                            'min' => "min({$this->wrap('value')})",
-                            'max' => "max({$this->wrap('value')})",
-                            'sum' => "sum({$this->wrap('value')})",
-                            'avg' => "avg({$this->wrap('value')})",
-                            default => $this->invalidAggregate($aggregate),
-                        }." as {$this->wrap($aggregate)}");
+                        $query->selectRaw($this->tailAggregate($aggregate)." as {$this->wrap($aggregate)}");
                     }
 
                     $query
@@ -661,14 +654,7 @@ class DatabaseStorage implements Storage
 
                             foreach ($aggregates as $aggregate) {
                                 if ($aggregate === $currentAggregate) {
-                                    $query->selectRaw(match ($aggregate) {
-                                        'count' => "sum({$this->wrap('value')})",
-                                        'min' => "min({$this->wrap('value')})",
-                                        'max' => "max({$this->wrap('value')})",
-                                        'sum' => "sum({$this->wrap('value')})",
-                                        'avg' => "avg({$this->wrap('value')})",
-                                        default => $this->invalidAggregate($aggregate),
-                                    }." as {$this->wrap($aggregate)}");
+                                    $query->selectRaw($this->bucketAggregate($aggregate)." as {$this->wrap($aggregate)}");
                                 } else {
                                     $query->selectRaw("null as {$this->wrap($aggregate)}");
                                 }
@@ -801,6 +787,39 @@ class DatabaseStorage implements Storage
     protected function invalidAggregate(string $aggregate): string
     {
         throw new InvalidArgumentException("Invalid aggregate type [$aggregate], allowed types: [".implode(', ', $this->allowedAggregates).'].');
+    }
+
+    /**
+     * SQL for one aggregate over the raw "tail" rows (vigilance_entries). Taking
+     * a plain string keeps the match's default reachable regardless of how tight
+     * the caller's type is narrowed, so static analysis stays version-stable.
+     */
+    protected function tailAggregate(string $aggregate): string
+    {
+        return match ($aggregate) {
+            'count' => 'count(*)',
+            'min' => "min({$this->wrap('value')})",
+            'max' => "max({$this->wrap('value')})",
+            'sum' => "sum({$this->wrap('value')})",
+            'avg' => "avg({$this->wrap('value')})",
+            default => $this->invalidAggregate($aggregate),
+        };
+    }
+
+    /**
+     * SQL for one aggregate over the pre-rolled bucket rows (vigilance_aggregates),
+     * where a stored "count" is itself a partial sum to be re-summed.
+     */
+    protected function bucketAggregate(string $aggregate): string
+    {
+        return match ($aggregate) {
+            'count' => "sum({$this->wrap('value')})",
+            'min' => "min({$this->wrap('value')})",
+            'max' => "max({$this->wrap('value')})",
+            'sum' => "sum({$this->wrap('value')})",
+            'avg' => "avg({$this->wrap('value')})",
+            default => $this->invalidAggregate($aggregate),
+        };
     }
 
     /**

--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -7,14 +7,28 @@ use Vigilance\Supervision\ControlPlane;
 
 class ContinueCommand extends Command
 {
-    protected $signature = 'vigilance:continue';
+    protected $signature = 'vigilance:continue
+        {--queue= : Resume only this queue}
+        {--connection= : Connection the queue lives on (defaults to vigilance.defaults.connection)}';
 
-    protected $description = 'Resume all paused Vigilance supervisors.';
+    protected $description = 'Resume all paused Vigilance supervisors, or a single queue with --queue.';
 
     public function handle(ControlPlane $control): int
     {
-        $control->continue();
-        $this->components->info('Vigilance resumed.');
+        $queue = $this->option('queue');
+
+        if ($queue === null || $queue === '') {
+            $control->continue();
+            $this->components->info('Vigilance resumed.');
+
+            return self::SUCCESS;
+        }
+
+        $connection = (string) ($this->option('connection') ?: config('vigilance.defaults.connection', 'database'));
+
+        $control->continueQueue($connection, $queue);
+
+        $this->components->info("Queue [{$connection}:{$queue}] resumed.");
 
         return self::SUCCESS;
     }

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -7,14 +7,31 @@ use Vigilance\Supervision\ControlPlane;
 
 class PauseCommand extends Command
 {
-    protected $signature = 'vigilance:pause';
+    protected $signature = 'vigilance:pause
+        {--queue= : Pause only this queue (leave the other queues running)}
+        {--connection= : Connection the queue lives on (defaults to vigilance.defaults.connection)}
+        {--for= : Auto-resume after this many seconds (default: pause indefinitely)}';
 
-    protected $description = 'Pause all Vigilance supervisors (workers stop processing new jobs).';
+    protected $description = 'Pause all Vigilance supervisors, or a single queue with --queue.';
 
     public function handle(ControlPlane $control): int
     {
-        $control->pause();
-        $this->components->info('Vigilance paused.');
+        $queue = $this->option('queue');
+
+        if ($queue === null || $queue === '') {
+            $control->pause();
+            $this->components->info('Vigilance paused.');
+
+            return self::SUCCESS;
+        }
+
+        $connection = (string) ($this->option('connection') ?: config('vigilance.defaults.connection', 'database'));
+        $for = $this->option('for');
+        $seconds = $for !== null && $for !== '' ? max(1, (int) $for) : null;
+
+        $control->pauseQueue($connection, $queue, $seconds);
+
+        $this->components->info("Queue [{$connection}:{$queue}] paused".($seconds !== null ? " for {$seconds}s." : '.'));
 
         return self::SUCCESS;
     }

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -18,6 +18,17 @@ class StatusCommand extends Command
         $this->newLine();
         $this->components->twoColumnDetail('<fg=cyan;options=bold>Vigilance supervision</>', 'control: '.$control->status());
 
+        foreach ($control->pausedQueues() as $paused) {
+            $until = $paused['expires_at'] !== null
+                ? 'until '.date('H:i:s', $paused['expires_at'])
+                : 'indefinitely';
+
+            $this->components->twoColumnDetail(
+                '  <fg=yellow>paused queue</> <fg=gray>'.$paused['connection'].' · '.$paused['queue'].'</>',
+                $until,
+            );
+        }
+
         $supervisors = $state->active((int) config('vigilance.supervision.heartbeat_expire', 30));
 
         if ($supervisors->isEmpty()) {

--- a/src/Control/QueueManager.php
+++ b/src/Control/QueueManager.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Vigilance\Control;
+
+use Illuminate\Contracts\Queue\ClearableQueue;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Vigilance\Control\Exceptions\NotAllowed;
+use Vigilance\Supervision\ControlPlane;
+
+/**
+ * The queue-level control surface behind the dashboard: pause / resume a single
+ * queue, purge a queue's backlog, and cancel individual pending jobs. Pausing is
+ * an operational lever (safe, like the global pause) and is always available;
+ * the destructive purge/cancel operations require the manual-control master
+ * switch (vigilance.control.enabled) and are always audited.
+ */
+class QueueManager
+{
+    public function __construct(
+        protected ControlPlane $control = new ControlPlane,
+        protected AuditLogger $audit = new AuditLogger,
+    ) {}
+
+    /**
+     * Pause a single queue. $seconds gives a timed pause that auto-resumes; null
+     * pauses indefinitely. The supervisor stops pulling from this queue on its
+     * next tick while every other queue keeps running.
+     */
+    public function pause(string $connection, string $queue, ?int $seconds = null, ?string $user = null): void
+    {
+        $this->control->pauseQueue($connection, $queue, $seconds);
+
+        $this->audit->log(
+            action: 'pause_queue',
+            subject: $connection.':'.$queue,
+            meta: ['connection' => $connection, 'queue' => $queue, 'seconds' => $seconds],
+            user: $user,
+        );
+    }
+
+    public function resume(string $connection, string $queue, ?string $user = null): void
+    {
+        $this->control->continueQueue($connection, $queue);
+
+        $this->audit->log(
+            action: 'resume_queue',
+            subject: $connection.':'.$queue,
+            meta: ['connection' => $connection, 'queue' => $queue],
+            user: $user,
+        );
+    }
+
+    /**
+     * Delete every job waiting on a queue. Works for any connection whose queue
+     * implements Laravel's ClearableQueue (database, redis, sqs). Beanstalkd and
+     * sync/null do not, and are rejected with NotAllowed. Returns the number of
+     * jobs removed (0 when the driver does not report a count).
+     *
+     * @throws NotAllowed when manual control is disabled or the driver can't be cleared
+     */
+    public function clear(string $connection, string $queue, ?string $user = null): int
+    {
+        $this->ensureControlEnabled();
+
+        $instance = Queue::connection($connection);
+
+        if (! $instance instanceof ClearableQueue) {
+            throw new NotAllowed("The [{$connection}] queue driver does not support clearing.");
+        }
+
+        $count = (int) $instance->clear($queue);
+
+        $this->audit->log(
+            action: 'clear_queue',
+            subject: $connection.':'.$queue,
+            meta: ['connection' => $connection, 'queue' => $queue, 'deleted' => $count],
+            user: $user,
+        );
+
+        return $count;
+    }
+
+    /**
+     * Cancel (delete) specific pending jobs by their backend id. Supported for
+     * the database driver only — other drivers have no addressable per-job
+     * handle to delete (use clear() to purge the whole queue there).
+     *
+     * @param  list<int>  $ids
+     *
+     * @throws NotAllowed when manual control is disabled or the driver is not "database"
+     */
+    public function deletePending(string $connection, array $ids, ?string $user = null): int
+    {
+        $this->ensureControlEnabled();
+
+        if (config("queue.connections.{$connection}.driver") !== 'database') {
+            throw new NotAllowed("Cancelling individual pending jobs is only supported for the database driver, not [{$connection}].");
+        }
+
+        $ids = array_values(array_filter(array_map('intval', $ids), fn (int $id) => $id > 0));
+
+        if ($ids === []) {
+            return 0;
+        }
+
+        $deleted = (int) DB::connection(config("queue.connections.{$connection}.connection"))
+            ->table((string) config("queue.connections.{$connection}.table", 'jobs'))
+            ->whereIn('id', $ids)
+            ->delete();
+
+        $this->audit->log(
+            action: 'cancel_pending',
+            subject: $connection,
+            meta: ['connection' => $connection, 'ids' => $ids, 'deleted' => $deleted],
+            user: $user,
+        );
+
+        return $deleted;
+    }
+
+    protected function ensureControlEnabled(): void
+    {
+        if (! config('vigilance.control.enabled', false)) {
+            throw new NotAllowed('Manual control is disabled. Set VIGILANCE_CONTROL_ENABLED=true to purge queues or cancel jobs from the dashboard.');
+        }
+    }
+}

--- a/src/Http/Livewire/Pending.php
+++ b/src/Http/Livewire/Pending.php
@@ -3,15 +3,70 @@
 namespace Vigilance\Http\Livewire;
 
 use Livewire\Component;
+use Vigilance\Control\Exceptions\NotAllowed;
+use Vigilance\Control\QueueManager;
 use Vigilance\Metrics\PendingJobs;
 use Vigilance\Models\Run;
+use Vigilance\Vigilance;
 
 /**
  * Live contents of the queue backend (jobs waiting to be processed), per
- * connection. Browsable for the database driver; other drivers are noted.
+ * connection. Browsable for the database driver; other drivers are noted. When
+ * manual control is enabled, individual pending jobs can be cancelled from here.
  */
 class Pending extends Component
 {
+    /**
+     * Selected pending jobs, each entry "connection#id" so ids never collide
+     * across connections.
+     *
+     * @var list<string>
+     */
+    public array $selected = [];
+
+    /**
+     * Cancel the selected pending jobs on the given connection (database driver
+     * only). Silently no-ops when nothing on this connection is selected.
+     */
+    public function cancelSelected(string $connection): void
+    {
+        $ids = [];
+
+        foreach ($this->selected as $entry) {
+            [$conn, $id] = array_pad(explode('#', (string) $entry, 2), 2, null);
+
+            if ($conn === $connection && $id !== null && is_numeric($id)) {
+                $ids[] = (int) $id;
+            }
+        }
+
+        if ($ids === []) {
+            $this->flash('error', 'No pending jobs selected on this connection.');
+
+            return;
+        }
+
+        try {
+            $deleted = app(QueueManager::class)->deletePending($connection, $ids, Vigilance::currentUser());
+        } catch (NotAllowed $e) {
+            $this->flash('error', $e->getMessage());
+
+            return;
+        }
+
+        $this->selected = array_values(array_filter(
+            $this->selected,
+            fn (string $entry) => ! str_starts_with($entry, $connection.'#'),
+        ));
+
+        $this->flash('success', "Cancelled {$deleted} pending job(s).");
+    }
+
+    protected function flash(string $type, string $message): void
+    {
+        session()->flash('vigilance.flash', ['type' => $type, 'message' => $message]);
+    }
+
     public function render()
     {
         $connections = Run::query()
@@ -29,7 +84,9 @@ class Pending extends Component
             'jobs' => $pending->for($connection),
         ])->all();
 
-        return view('vigilance::pages.pending', ['groups' => $groups])
-            ->layout('vigilance::layout', ['title' => 'Pending']);
+        return view('vigilance::pages.pending', [
+            'groups' => $groups,
+            'controlEnabled' => (bool) config('vigilance.control.enabled', false),
+        ])->layout('vigilance::layout', ['title' => 'Pending']);
     }
 }

--- a/src/Http/Livewire/Workload.php
+++ b/src/Http/Livewire/Workload.php
@@ -3,24 +3,75 @@
 namespace Vigilance\Http\Livewire;
 
 use Livewire\Component;
+use Vigilance\Control\Exceptions\NotAllowed;
+use Vigilance\Control\QueueManager;
 use Vigilance\Metrics\Stats;
 use Vigilance\Metrics\Workload as WorkloadMetrics;
+use Vigilance\Supervision\ControlPlane;
+use Vigilance\Vigilance;
 
 /**
  * Per-queue workload: depth (database/redis only), last-hour throughput,
  * average runtime and a throughput sparkline; system load; and a per-job-class
- * performance breakdown.
+ * performance breakdown. Also the home of the per-queue control levers —
+ * pause / resume (any driver) and clear (destructive, gated by control.enabled).
  */
 class Workload extends Component
 {
+    public function pauseQueue(string $connection, string $queue, ?int $minutes = null): void
+    {
+        app(QueueManager::class)->pause(
+            $connection,
+            $queue,
+            $minutes !== null ? $minutes * 60 : null,
+            Vigilance::currentUser(),
+        );
+
+        $this->flash('success', $minutes !== null
+            ? "Queue [{$queue}] paused for {$minutes} min."
+            : "Queue [{$queue}] paused.");
+    }
+
+    public function resumeQueue(string $connection, string $queue): void
+    {
+        app(QueueManager::class)->resume($connection, $queue, Vigilance::currentUser());
+
+        $this->flash('success', "Queue [{$queue}] resumed.");
+    }
+
+    public function clearQueue(string $connection, string $queue): void
+    {
+        try {
+            $deleted = app(QueueManager::class)->clear($connection, $queue, Vigilance::currentUser());
+        } catch (NotAllowed $e) {
+            $this->flash('error', $e->getMessage());
+
+            return;
+        }
+
+        $this->flash('success', "Cleared {$deleted} job(s) from [{$queue}].");
+    }
+
+    protected function flash(string $type, string $message): void
+    {
+        session()->flash('vigilance.flash', ['type' => $type, 'message' => $message]);
+    }
+
     public function render()
     {
         $workload = app(WorkloadMetrics::class);
+
+        $paused = [];
+        foreach (app(ControlPlane::class)->pausedQueues() as $entry) {
+            $paused[$entry['connection'].'|'.$entry['queue']] = $entry['expires_at'];
+        }
 
         return view('vigilance::pages.workload', [
             'queues' => $workload->queues(),
             'load' => $workload->load(),
             'jobClasses' => app(Stats::class)->byJobClass(),
+            'paused' => $paused,
+            'controlEnabled' => (bool) config('vigilance.control.enabled', false),
         ])->layout('vigilance::layout', ['title' => 'Workload']);
     }
 }

--- a/src/Mcp/Tools/CancelPendingTool.php
+++ b/src/Mcp/Tools/CancelPendingTool.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\Exceptions\NotAllowed;
+use Vigilance\Control\QueueManager;
+
+#[Description('Cancel (delete) specific pending jobs by their backend id — database driver only. Destructive and irreversible. Requires BOTH manual control (VIGILANCE_CONTROL_ENABLED=true) AND MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited. Discover ids with "pending"; to purge a whole queue use "clear-queue".')]
+#[IsDestructive]
+class CancelPendingTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->controlEnabled() && $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'connection' => $schema->string()
+                ->description('The queue connection (must use the database driver).')
+                ->required(),
+            'ids' => $schema->array()
+                ->items($schema->integer())
+                ->description('The pending job ids to cancel (from the "pending" tool).')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request, QueueManager $queues): Response
+    {
+        if (! $this->controlEnabled() || ! $this->writesEnabled()) {
+            return Response::error('Cancelling pending jobs requires both vigilance.control.enabled and vigilance.mcp.allow_writes to be true.');
+        }
+
+        $connection = trim((string) $request->get('connection'));
+
+        if ($connection === '') {
+            return Response::error('The "connection" parameter is required.');
+        }
+
+        $ids = array_values(array_filter(
+            array_map('intval', (array) $request->get('ids', [])),
+            fn (int $id) => $id > 0,
+        ));
+
+        if ($ids === []) {
+            return Response::error('Provide at least one valid job id in "ids".');
+        }
+
+        try {
+            $deleted = $queues->deletePending($connection, $ids, $this->actor($request));
+        } catch (NotAllowed $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return $this->json(['ok' => true, 'connection' => $connection, 'requested' => count($ids), 'deleted' => $deleted]);
+    }
+}

--- a/src/Mcp/Tools/ClearQueueTool.php
+++ b/src/Mcp/Tools/ClearQueueTool.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\Exceptions\NotAllowed;
+use Vigilance\Control\QueueManager;
+
+#[Description('Delete EVERY job waiting on a queue (purges the backlog for drivers that support clearing: database, redis, sqs — beanstalkd/sync are rejected). Destructive and irreversible. Requires BOTH manual control (VIGILANCE_CONTROL_ENABLED=true) AND MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited. To cancel specific jobs instead, use "cancel-pending".')]
+#[IsDestructive]
+class ClearQueueTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->controlEnabled() && $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'connection' => $schema->string()
+                ->description('The queue connection to clear on (e.g. "redis").')
+                ->required(),
+            'queue' => $schema->string()
+                ->description('The queue name to purge (e.g. "default").')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request, QueueManager $queues): Response
+    {
+        if (! $this->controlEnabled() || ! $this->writesEnabled()) {
+            return Response::error('Clearing a queue requires both vigilance.control.enabled and vigilance.mcp.allow_writes to be true.');
+        }
+
+        $connection = trim((string) $request->get('connection'));
+        $queue = trim((string) $request->get('queue'));
+
+        if ($connection === '' || $queue === '') {
+            return Response::error('Both "connection" and "queue" are required.');
+        }
+
+        try {
+            $deleted = $queues->clear($connection, $queue, $this->actor($request));
+        } catch (NotAllowed $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return $this->json(['ok' => true, 'connection' => $connection, 'queue' => $queue, 'deleted' => $deleted]);
+    }
+}

--- a/src/Mcp/Tools/ControlWorkersTool.php
+++ b/src/Mcp/Tools/ControlWorkersTool.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\AuditLogger;
+use Vigilance\Supervision\ControlPlane;
+
+#[Description('Control the whole Vigilance worker fleet — the global control plane behind vigilance:pause / continue / restart / terminate. Actions: "pause" (workers stop pulling new jobs), "resume", "restart" (rolling restart, e.g. after a deploy), "terminate" (gracefully stop the supervisor and all workers). Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited. To pause a single queue instead of the whole fleet, use "pause-queue".')]
+#[IsDestructive]
+class ControlWorkersTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'action' => $schema->string()
+                ->description('What to do to the fleet.')
+                ->enum(['pause', 'resume', 'restart', 'terminate'])
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request, ControlPlane $control, AuditLogger $audit): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        $action = (string) $request->get('action');
+
+        match ($action) {
+            'pause' => $control->pause(),
+            'resume' => $control->continue(),
+            'restart' => $control->restart(),
+            'terminate' => $control->terminate(),
+            default => null,
+        };
+
+        if (! in_array($action, ['pause', 'resume', 'restart', 'terminate'], true)) {
+            return Response::error('Unknown action. Use one of: pause, resume, restart, terminate.');
+        }
+
+        $audit->log(
+            action: $action.'_workers',
+            meta: ['source' => 'mcp'],
+            user: $this->actor($request),
+        );
+
+        return $this->json(['ok' => true, 'action' => $action, 'control' => $control->status()]);
+    }
+}

--- a/src/Mcp/Tools/PauseQueueTool.php
+++ b/src/Mcp/Tools/PauseQueueTool.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\QueueManager;
+
+#[Description('Pause a single queue: the supervisor stops pulling from it while every other queue keeps draining. Optionally auto-resume after "seconds"; otherwise it stays paused (surviving worker restarts/deploys) until resumed with "resume-queue". Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited. Use "queues" to see connections/queue names and their current paused state.')]
+#[IsDestructive]
+class PauseQueueTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'queue' => $schema->string()
+                ->description('The queue name to pause (e.g. "emails").')
+                ->required(),
+            'connection' => $schema->string()
+                ->description('The queue connection the queue lives on. Defaults to vigilance.defaults.connection.'),
+            'seconds' => $schema->integer()
+                ->description('Auto-resume after this many seconds. Omit for an indefinite pause.'),
+        ];
+    }
+
+    public function handle(Request $request, QueueManager $queues): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        $queue = trim((string) $request->get('queue'));
+
+        if ($queue === '') {
+            return Response::error('The "queue" parameter is required.');
+        }
+
+        $connection = trim((string) $request->get('connection'))
+            ?: (string) config('vigilance.defaults.connection', 'database');
+
+        $seconds = $request->get('seconds') !== null ? max(1, $request->integer('seconds')) : null;
+
+        $queues->pause($connection, $queue, $seconds, $this->actor($request));
+
+        return $this->json([
+            'ok' => true,
+            'connection' => $connection,
+            'queue' => $queue,
+            'paused_for_seconds' => $seconds,
+        ]);
+    }
+}

--- a/src/Mcp/Tools/QueuesTool.php
+++ b/src/Mcp/Tools/QueuesTool.php
@@ -2,22 +2,31 @@
 
 namespace Vigilance\Mcp\Tools;
 
+use Illuminate\Support\Carbon;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Vigilance\Metrics\Workload;
+use Vigilance\Supervision\ControlPlane;
 
-#[Description('Per-queue workload over the recent window: live backlog depth, active worker count, last-hour throughput / failures / average runtime / average wait, and an estimated time-to-clear the backlog.')]
+#[Description('Per-queue workload over the recent window: live backlog depth, active worker count, last-hour throughput / failures / average runtime / average wait, an estimated time-to-clear the backlog, and whether the queue is currently paused. Also lists every paused queue with its auto-resume expiry.')]
 #[IsReadOnly]
 class QueuesTool extends Tool
 {
-    public function handle(Request $request, Workload $workload): Response
+    public function handle(Request $request, Workload $workload, ControlPlane $control): Response
     {
-        $queues = array_map(function (array $queue): array {
+        $paused = [];
+        foreach ($control->pausedQueues() as $entry) {
+            $paused[$entry['connection'].'|'.$entry['queue']] = $entry['expires_at'];
+        }
+
+        $queues = array_map(function (array $queue) use ($paused): array {
             // Drop the per-queue sparkline series — the agent wants the numbers,
             // not 60 points of history.
             unset($queue['series']);
+
+            $queue['paused'] = array_key_exists(($queue['connection_name'] ?? '').'|'.$queue['queue'], $paused);
 
             return $queue;
         }, $workload->queues());
@@ -25,6 +34,11 @@ class QueuesTool extends Tool
         return $this->json([
             'count' => count($queues),
             'queues' => $queues,
+            'paused_queues' => array_map(fn (array $e): array => [
+                'connection' => $e['connection'],
+                'queue' => $e['queue'],
+                'expires_at' => $e['expires_at'] !== null ? $this->date(Carbon::createFromTimestamp($e['expires_at'])) : null,
+            ], $control->pausedQueues()),
         ]);
     }
 }

--- a/src/Mcp/Tools/ResumeQueueTool.php
+++ b/src/Mcp/Tools/ResumeQueueTool.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\QueueManager;
+
+#[Description('Resume a single paused queue so the supervisor starts pulling from it again. Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited.')]
+#[IsDestructive]
+class ResumeQueueTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'queue' => $schema->string()
+                ->description('The queue name to resume.')
+                ->required(),
+            'connection' => $schema->string()
+                ->description('The queue connection the queue lives on. Defaults to vigilance.defaults.connection.'),
+        ];
+    }
+
+    public function handle(Request $request, QueueManager $queues): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        $queue = trim((string) $request->get('queue'));
+
+        if ($queue === '') {
+            return Response::error('The "queue" parameter is required.');
+        }
+
+        $connection = trim((string) $request->get('connection'))
+            ?: (string) config('vigilance.defaults.connection', 'database');
+
+        $queues->resume($connection, $queue, $this->actor($request));
+
+        return $this->json(['ok' => true, 'connection' => $connection, 'queue' => $queue, 'status' => 'resumed']);
+    }
+}

--- a/src/Mcp/Tools/WorkersTool.php
+++ b/src/Mcp/Tools/WorkersTool.php
@@ -9,13 +9,14 @@ use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Vigilance\Models\SupervisorRecord;
 use Vigilance\Models\WorkerRecord;
+use Vigilance\Supervision\ControlPlane;
 use Vigilance\Supervision\SupervisorState;
 
-#[Description('The worker fleet (the Horizon-replacement supervisor view): every live supervisor across all nodes — connection, queues, process count, balance, status, heartbeat — and the worker processes it owns. Empty if you run queue:work/Horizon instead of vigilance:supervise.')]
+#[Description('The worker fleet (the Horizon-replacement supervisor view): the global control status (running/paused/terminating), every live supervisor across all nodes — connection, queues, process count, balance, status, heartbeat — and the worker processes it owns. Empty if you run queue:work/Horizon instead of vigilance:supervise. Use "control-workers" to pause/resume/restart the fleet.')]
 #[IsReadOnly]
 class WorkersTool extends Tool
 {
-    public function handle(Request $request, SupervisorState $state): Response
+    public function handle(Request $request, SupervisorState $state, ControlPlane $control): Response
     {
         $expire = (int) config('vigilance.supervision.heartbeat_expire', 30);
 
@@ -28,6 +29,7 @@ class WorkersTool extends Tool
             ->groupBy(fn (WorkerRecord $w): string => $w->supervisor.'@'.$w->host);
 
         return $this->json([
+            'control' => $control->status(),
             'count' => $supervisors->count(),
             'supervisors' => $supervisors->map(function (SupervisorRecord $s) use ($workers): array {
                 /** @var Collection<int, WorkerRecord> $own */

--- a/src/Mcp/VigilanceServer.php
+++ b/src/Mcp/VigilanceServer.php
@@ -9,6 +9,9 @@ use Laravel\Mcp\Server\Tool;
 use Vigilance\Mcp\Tools\AcknowledgeIssueTool;
 use Vigilance\Mcp\Tools\BatchesTool;
 use Vigilance\Mcp\Tools\CacheTool;
+use Vigilance\Mcp\Tools\CancelPendingTool;
+use Vigilance\Mcp\Tools\ClearQueueTool;
+use Vigilance\Mcp\Tools\ControlWorkersTool;
 use Vigilance\Mcp\Tools\CustomMetricsTool;
 use Vigilance\Mcp\Tools\DispatchableJobsTool;
 use Vigilance\Mcp\Tools\DispatchJobTool;
@@ -20,12 +23,14 @@ use Vigilance\Mcp\Tools\JobMetricsTool;
 use Vigilance\Mcp\Tools\LogsTool;
 use Vigilance\Mcp\Tools\MuteIssueTool;
 use Vigilance\Mcp\Tools\OverviewTool;
+use Vigilance\Mcp\Tools\PauseQueueTool;
 use Vigilance\Mcp\Tools\PendingTool;
 use Vigilance\Mcp\Tools\PerformanceTool;
 use Vigilance\Mcp\Tools\QueuesTool;
 use Vigilance\Mcp\Tools\ReleasesTool;
 use Vigilance\Mcp\Tools\ReopenIssueTool;
 use Vigilance\Mcp\Tools\ResolveIssueTool;
+use Vigilance\Mcp\Tools\ResumeQueueTool;
 use Vigilance\Mcp\Tools\RetryIssueTool;
 use Vigilance\Mcp\Tools\RetryRunTool;
 use Vigilance\Mcp\Tools\RunCommandTool;
@@ -77,9 +82,18 @@ class VigilanceServer extends Server
         - "logs", "slos", "incidents", "releases" — logs, error budgets, open incidents, deploy health.
 
         Tools are read-only unless the operator enabled writes; when enabled you
-        may also resolve / acknowledge / mute an issue, reopen it, and retry a
-        failed job (each is recorded in Vigilance's audit log). Output is redacted
-        and truncated, so an absent or shortened field may simply be capped.
+        may also resolve / acknowledge / mute an issue, reopen it, retry a failed
+        job, and drive the worker fleet:
+        - "control-workers" — pause / resume / restart / terminate every supervisor.
+        - "pause-queue" / "resume-queue" — pause a single queue (optionally timed)
+          while the others keep draining; check "queues" for the paused state first.
+        - "clear-queue" — purge a whole queue's backlog (any driver).
+        - "cancel-pending" — delete specific waiting jobs by id (database driver);
+          discover ids with "pending".
+        The destructive "clear-queue"/"cancel-pending" additionally require manual
+        control (VIGILANCE_CONTROL_ENABLED=true). Every write is recorded in
+        Vigilance's audit log. Output is redacted and truncated, so an absent or
+        shortened field may simply be capped.
         MARKDOWN;
 
     /**
@@ -124,6 +138,14 @@ class VigilanceServer extends Server
         ReopenIssueTool::class,
         RetryRunTool::class,
         RetryIssueTool::class,
+        // Worker & queue control (self-gate on mcp.allow_writes). Pausing/resuming
+        // a queue or the fleet is operational; clearing a queue and cancelling
+        // pending jobs are destructive and additionally require control.enabled.
+        ControlWorkersTool::class,
+        PauseQueueTool::class,
+        ResumeQueueTool::class,
+        ClearQueueTool::class,
+        CancelPendingTool::class,
         // Manual control: discovery tools gate on control.enabled; the
         // dispatch/run tools additionally require mcp.allow_writes.
         DispatchableJobsTool::class,

--- a/src/Supervision/ControlPlane.php
+++ b/src/Supervision/ControlPlane.php
@@ -19,6 +19,8 @@ class ControlPlane
 
     public const TERMINATING = 'terminating';
 
+    protected const PAUSED_QUEUES = 'vigilance:control:paused-queues';
+
     protected function cache(): Repository
     {
         return Cache::store(config('vigilance.supervision.cache_store'));
@@ -73,9 +75,115 @@ class ControlPlane
     /**
      * Clear control flags — called when a fresh supervisor boots so a stale
      * "terminating"/"paused" flag from a previous run doesn't immediately stop it.
+     *
+     * Per-queue pauses are deliberately NOT cleared here: they express an operator
+     * intent ("stop draining this queue") that should survive a worker restart or
+     * deploy until it is explicitly resumed or its duration lapses.
      */
     public function reset(): void
     {
         $this->cache()->forever('vigilance:control:status', self::RUNNING);
+    }
+
+    /**
+     * Pause a single queue on a connection. The supervisor stops pulling from it
+     * (narrowing multi-queue pools to their still-active queues) while leaving
+     * every other queue running. Pass $seconds for a timed pause that
+     * auto-resumes; null pauses indefinitely.
+     */
+    public function pauseQueue(string $connection, string $queue, ?int $seconds = null): void
+    {
+        $map = $this->pausedQueueMap();
+        $map[$connection][$queue] = $seconds !== null && $seconds > 0 ? time() + $seconds : null;
+
+        $this->cache()->forever(self::PAUSED_QUEUES, $map);
+    }
+
+    public function continueQueue(string $connection, string $queue): void
+    {
+        $map = $this->pausedQueueMap();
+
+        unset($map[$connection][$queue]);
+
+        if (($map[$connection] ?? null) === []) {
+            unset($map[$connection]);
+        }
+
+        $this->cache()->forever(self::PAUSED_QUEUES, $map);
+    }
+
+    public function isQueuePaused(string $connection, string $queue): bool
+    {
+        return array_key_exists($queue, $this->pausedQueueMap()[$connection] ?? []);
+    }
+
+    /**
+     * Every currently-paused queue, oldest expiry semantics resolved: entries
+     * whose timed pause has lapsed are pruned before the list is returned.
+     *
+     * @return list<array{connection: string, queue: string, expires_at: ?int}>
+     */
+    public function pausedQueues(): array
+    {
+        $out = [];
+
+        foreach ($this->pausedQueueMap() as $connection => $queues) {
+            foreach ($queues as $queue => $expiresAt) {
+                $out[] = [
+                    'connection' => (string) $connection,
+                    'queue' => (string) $queue,
+                    'expires_at' => $expiresAt !== null ? (int) $expiresAt : null,
+                ];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * The paused-queue map, keyed [connection][queue] => expiry epoch (or null
+     * for indefinite), with lapsed timed pauses pruned. The pruned copy is
+     * written back so an expired pause self-heals without an operator or the
+     * supervisor having to act.
+     *
+     * @return array<string, array<string, ?int>>
+     */
+    protected function pausedQueueMap(): array
+    {
+        $map = $this->cache()->get(self::PAUSED_QUEUES, []);
+
+        if (! is_array($map)) {
+            return [];
+        }
+
+        $now = time();
+        $changed = false;
+
+        foreach ($map as $connection => $queues) {
+            if (! is_array($queues)) {
+                unset($map[$connection]);
+                $changed = true;
+
+                continue;
+            }
+
+            foreach ($queues as $queue => $expiresAt) {
+                if ($expiresAt !== null && (int) $expiresAt <= $now) {
+                    unset($map[$connection][$queue]);
+                    $changed = true;
+                }
+            }
+
+            if (($map[$connection] ?? null) === []) {
+                unset($map[$connection]);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            $this->cache()->forever(self::PAUSED_QUEUES, $map);
+        }
+
+        return $map;
     }
 }

--- a/src/Supervision/Pool.php
+++ b/src/Supervision/Pool.php
@@ -14,14 +14,56 @@ class Pool
     /** @var list<WorkerProcess> */
     protected array $workers = [];
 
+    /**
+     * The queues this pool's workers currently pull from. Defaults to the full
+     * pool key and is narrowed by per-queue pause (see setActiveQueues()); an
+     * empty string means every queue in the pool is paused.
+     */
+    protected string $activeKey;
+
     public function __construct(
         public string $key,
         protected SupervisorOptions $options,
-    ) {}
+    ) {
+        $this->activeKey = $key;
+    }
 
     public function count(): int
     {
         return count($this->workers);
+    }
+
+    /**
+     * The queues this pool is currently serving (its key, narrowed by any
+     * per-queue pause). Empty string when every queue in the pool is paused.
+     */
+    public function activeQueues(): string
+    {
+        return $this->activeKey;
+    }
+
+    /**
+     * Narrow (or restore) the queues this pool serves — the mechanism behind
+     * per-queue pause. When the active set changes, running workers are stopped
+     * so they relaunch bound to the new `--queue` list on the next scale/monitor;
+     * an empty set fully pauses the pool. A no-op when the set is unchanged, so
+     * steady state never cycles workers.
+     */
+    public function setActiveQueues(string $activeKey): void
+    {
+        if ($activeKey === $this->activeKey) {
+            return;
+        }
+
+        $this->activeKey = $activeKey;
+
+        foreach ($this->workers as $worker) {
+            $worker->terminate($this->options->timeout);
+        }
+
+        $this->workers = [];
+
+        $this->reap();
     }
 
     /**
@@ -31,6 +73,12 @@ class Pool
     public function scaleTo(int $target): void
     {
         $target = max(0, $target);
+
+        // No queues left active (fully paused): never launch a worker with an
+        // empty --queue list — hold the pool at zero.
+        if ($this->activeKey === '') {
+            $target = 0;
+        }
 
         while (count($this->workers) < $target) {
             $this->workers[] = $this->launch();
@@ -169,7 +217,7 @@ class Pool
             $pid = $worker->pid();
 
             if ($pid !== null) {
-                $out[] = ['pid' => $pid, 'queue' => $this->key];
+                $out[] = ['pid' => $pid, 'queue' => $this->activeKey];
             }
         }
 
@@ -201,14 +249,14 @@ class Pool
         $command = array_merge(
             $this->options->niceWrapper(),
             [$this->phpBinary(), base_path('artisan')],
-            $this->options->workerCommand($this->key),
+            $this->options->workerCommand($this->activeKey),
         );
 
         $process = new Process($command, base_path());
         $process->setTimeout(null);
         $process->disableOutput();
 
-        return (new WorkerProcess($process, $this->key))->start();
+        return (new WorkerProcess($process, $this->activeKey))->start();
     }
 
     protected function phpBinary(): string

--- a/src/Supervision/Supervisor.php
+++ b/src/Supervision/Supervisor.php
@@ -57,10 +57,19 @@ class Supervisor
         $this->working = ! $this->control->isPaused();
 
         if ($this->working) {
-            $this->autoScale();
+            // Per-queue pause: narrow each pool to its still-active queues. Pools
+            // whose every queue is paused are held at zero; the rest scale and
+            // monitor as usual.
+            $activePools = $this->applyQueuePauses();
 
-            foreach ($this->pools as $pool) {
-                $pool->monitor();
+            $this->autoScale($activePools);
+
+            foreach ($this->pools as $key => $pool) {
+                if (in_array($key, $activePools, true)) {
+                    $pool->monitor();
+                } else {
+                    $pool->scaleTo(0);
+                }
             }
         } else {
             foreach ($this->pools as $pool) {
@@ -71,6 +80,34 @@ class Supervisor
         $this->heartbeat();
 
         return true;
+    }
+
+    /**
+     * Push the current per-queue pause state down to the pools and report which
+     * pools still have work to do. A pool serving several queues (balance=false)
+     * is narrowed to just its unpaused queues; a pool whose queues are all paused
+     * is omitted from the returned list so tick() holds it at zero workers.
+     *
+     * @return list<string> keys of pools with at least one active queue
+     */
+    protected function applyQueuePauses(): array
+    {
+        $active = [];
+
+        foreach ($this->pools as $key => $pool) {
+            $live = array_values(array_filter(
+                explode(',', $key),
+                fn (string $queue) => ! $this->control->isQueuePaused($this->options->connection, $queue),
+            ));
+
+            $pool->setActiveQueues(implode(',', $live));
+
+            if ($live !== []) {
+                $active[] = $key;
+            }
+        }
+
+        return $active;
     }
 
     public function terminate(): void
@@ -134,7 +171,23 @@ class Supervisor
         return array_sum(array_map(fn (Pool $p) => $p->count(), $this->pools));
     }
 
-    protected function autoScale(): void
+    /**
+     * The queues each pool is currently serving after per-queue pauses are
+     * applied (pool key => active queue list, '' when the pool is fully paused).
+     * Reflects the live decision the last tick() acted on.
+     *
+     * @return array<string, string>
+     */
+    public function poolActiveQueues(): array
+    {
+        return array_map(fn (Pool $p): string => $p->activeQueues(), $this->pools);
+    }
+
+    /**
+     * @param  list<string>  $activePools  pool keys eligible to scale this tick
+     *                                     (paused-out pools are handled by tick())
+     */
+    protected function autoScale(array $activePools): void
     {
         // Throttle how often the desired pool sizes are re-evaluated: at most once
         // per balance_cooldown seconds. Between evaluations the pools hold steady
@@ -161,8 +214,12 @@ class Supervisor
             fn (string $pool): float => $this->runtimeFor($pool),
         );
 
+        // Only resize pools that still have an active queue this tick — never
+        // spin up workers for a paused pool just to tear them down again below.
         foreach ($desired as $key => $target) {
-            $this->pools[$key]->scaleTo($target);
+            if (in_array($key, $activePools, true)) {
+                $this->pools[$key]->scaleTo($target);
+            }
         }
     }
 

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -18,7 +18,7 @@ use Vigilance\Support\Defaults;
  */
 class Vigilance
 {
-    public static string $version = '0.6.0';
+    public static string $version = '0.7.0';
 
     /** Cache-busting token for the bundled stylesheet, derived from its contents. */
     protected static ?string $assetVersion = null;

--- a/tests/Feature/QueueControlTest.php
+++ b/tests/Feature/QueueControlTest.php
@@ -1,0 +1,286 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+use Vigilance\Control\Exceptions\NotAllowed;
+use Vigilance\Control\QueueManager;
+use Vigilance\Http\Livewire\Pending;
+use Vigilance\Http\Livewire\Workload;
+use Vigilance\Metrics\QueueDepth;
+use Vigilance\Models\AuditEntry;
+use Vigilance\Supervision\AutoScaler;
+use Vigilance\Supervision\ControlPlane;
+use Vigilance\Supervision\Pool;
+use Vigilance\Supervision\Supervisor;
+use Vigilance\Supervision\SupervisorOptions;
+use Vigilance\Supervision\SupervisorState;
+use Vigilance\Vigilance;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Cache::store()->forget('vigilance:control:paused-queues');
+});
+
+/**
+ * Create the standard Laravel queue "jobs" table on the test connection and make
+ * sure it is empty. DDL auto-commits on MySQL (breaking RefreshDatabase's
+ * per-test transaction), so rows can otherwise leak between tests — purge to keep
+ * assertions deterministic across sqlite / mysql / postgres.
+ */
+function makeJobsTable(): void
+{
+    if (! Schema::hasTable('jobs')) {
+        Schema::create('jobs', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->string('queue')->index();
+            $t->longText('payload');
+            $t->unsignedTinyInteger('attempts');
+            $t->unsignedInteger('reserved_at')->nullable();
+            $t->unsignedInteger('available_at');
+            $t->unsignedInteger('created_at');
+        });
+    }
+
+    DB::table('jobs')->delete();
+}
+
+// ── ControlPlane: per-queue pause ────────────────────────────────────────────
+
+it('pauses and resumes a single queue without touching others', function () {
+    $control = app(ControlPlane::class);
+
+    $control->pauseQueue('database', 'emails');
+
+    expect($control->isQueuePaused('database', 'emails'))->toBeTrue()
+        ->and($control->isQueuePaused('database', 'default'))->toBeFalse()
+        ->and($control->isQueuePaused('redis', 'emails'))->toBeFalse();
+
+    $control->continueQueue('database', 'emails');
+
+    expect($control->isQueuePaused('database', 'emails'))->toBeFalse()
+        ->and($control->pausedQueues())->toBe([]);
+});
+
+it('lists paused queues with their expiry', function () {
+    $control = app(ControlPlane::class);
+
+    $control->pauseQueue('database', 'a');
+    $control->pauseQueue('database', 'b', 300);
+
+    $paused = collect($control->pausedQueues())->keyBy('queue');
+
+    expect($paused)->toHaveCount(2)
+        ->and($paused['a']['expires_at'])->toBeNull()
+        ->and($paused['b']['expires_at'])->toBeGreaterThan(time());
+});
+
+it('auto-expires a lapsed timed pause and keeps indefinite ones', function () {
+    // Seed the cache directly with one already-lapsed and one indefinite entry.
+    Cache::store()->forever('vigilance:control:paused-queues', [
+        'database' => ['lapsed' => time() - 5, 'forever' => null],
+    ]);
+
+    $control = app(ControlPlane::class);
+
+    expect($control->isQueuePaused('database', 'lapsed'))->toBeFalse()
+        ->and($control->isQueuePaused('database', 'forever'))->toBeTrue()
+        ->and($control->pausedQueues())->toHaveCount(1);
+});
+
+// ── Supervisor: honours a paused queue ───────────────────────────────────────
+
+it('runs no workers for a fully paused supervisor pool', function () {
+    $options = SupervisorOptions::fromArray([
+        'name' => 'pause-sup', 'connection' => 'database', 'queue' => ['emails'],
+        'balance' => false, 'min_processes' => 1, 'max_processes' => 2,
+    ]);
+
+    app(ControlPlane::class)->pauseQueue('database', 'emails');
+
+    $supervisor = new Supervisor(
+        $options,
+        new AutoScaler,
+        app(SupervisorState::class),
+        app(ControlPlane::class),
+        app(QueueDepth::class),
+    );
+
+    $supervisor->tick();
+
+    // The only queue is paused → no worker process is ever launched.
+    expect($supervisor->totalProcesses())->toBe(0);
+});
+
+it('never launches a pool whose active queue set is empty', function () {
+    $options = SupervisorOptions::fromArray(['queue' => ['default'], 'balance' => false]);
+    $pool = new Pool('default', $options);
+
+    $pool->setActiveQueues('');
+    $pool->scaleTo(3);
+
+    expect($pool->count())->toBe(0);
+});
+
+it('narrows a multi-queue pool to only its unpaused queues (balance=false)', function () {
+    // balance=false → a single pool serving "high,low". min_processes=0 keeps the
+    // tick from spawning any real worker process, so we can assert the narrowing
+    // decision deterministically.
+    $options = SupervisorOptions::fromArray([
+        'name' => 'narrow-sup', 'connection' => 'database', 'queue' => ['high', 'low'],
+        'balance' => false, 'min_processes' => 0, 'max_processes' => 2,
+    ]);
+
+    $control = app(ControlPlane::class);
+    $control->pauseQueue('database', 'low');
+
+    $supervisor = new Supervisor(
+        $options, new AutoScaler, app(SupervisorState::class), $control, app(QueueDepth::class),
+    );
+
+    $supervisor->tick();
+    expect($supervisor->poolActiveQueues())->toBe(['high,low' => 'high'])
+        ->and($supervisor->totalProcesses())->toBe(0);
+
+    // Resuming restores the full queue set on the next tick.
+    $control->continueQueue('database', 'low');
+    $supervisor->tick();
+    expect($supervisor->poolActiveQueues())->toBe(['high,low' => 'high,low']);
+});
+
+it('narrows to nothing when every queue in a balance=false pool is paused', function () {
+    $options = SupervisorOptions::fromArray([
+        'name' => 'all-paused', 'connection' => 'database', 'queue' => ['high', 'low'],
+        'balance' => false, 'min_processes' => 0, 'max_processes' => 2,
+    ]);
+
+    $control = app(ControlPlane::class);
+    $control->pauseQueue('database', 'high');
+    $control->pauseQueue('database', 'low');
+
+    $supervisor = new Supervisor(
+        $options, new AutoScaler, app(SupervisorState::class), $control, app(QueueDepth::class),
+    );
+
+    $supervisor->tick();
+
+    expect($supervisor->poolActiveQueues())->toBe(['high,low' => ''])
+        ->and($supervisor->totalProcesses())->toBe(0);
+});
+
+// ── CLI wiring ───────────────────────────────────────────────────────────────
+
+it('pauses and resumes a queue through the artisan commands', function () {
+    config()->set('vigilance.defaults.connection', 'database');
+
+    $this->artisan('vigilance:pause', ['--queue' => 'emails', '--for' => '120'])
+        ->assertSuccessful();
+
+    expect(app(ControlPlane::class)->isQueuePaused('database', 'emails'))->toBeTrue();
+
+    $this->artisan('vigilance:status')->assertSuccessful()->expectsOutputToContain('emails');
+
+    $this->artisan('vigilance:continue', ['--queue' => 'emails'])->assertSuccessful();
+
+    expect(app(ControlPlane::class)->isQueuePaused('database', 'emails'))->toBeFalse();
+});
+
+it('still pauses the whole fleet when no --queue is given', function () {
+    $this->artisan('vigilance:pause')->assertSuccessful();
+    expect(app(ControlPlane::class)->isPaused())->toBeTrue();
+
+    $this->artisan('vigilance:continue')->assertSuccessful();
+    expect(app(ControlPlane::class)->status())->toBe(ControlPlane::RUNNING);
+});
+
+// ── QueueManager: clear + cancel are gated and audited ───────────────────────
+
+it('refuses to clear or cancel when manual control is disabled', function () {
+    config()->set('vigilance.control.enabled', false);
+
+    expect(fn () => app(QueueManager::class)->clear('database', 'default'))
+        ->toThrow(NotAllowed::class);
+
+    expect(fn () => app(QueueManager::class)->deletePending('database', [1]))
+        ->toThrow(NotAllowed::class);
+});
+
+it('clears a queue and audits it', function () {
+    config()->set('vigilance.control.enabled', true);
+    config()->set('queue.connections.database', ['driver' => 'database', 'table' => 'jobs', 'queue' => 'default']);
+    makeJobsTable();
+
+    foreach (['default', 'default', 'other'] as $q) {
+        DB::table('jobs')->insert([
+            'queue' => $q, 'payload' => '{}', 'attempts' => 0,
+            'reserved_at' => null, 'available_at' => time(), 'created_at' => time(),
+        ]);
+    }
+
+    $deleted = app(QueueManager::class)->clear('database', 'default', 'admin@test');
+
+    expect($deleted)->toBe(2)
+        ->and(DB::table('jobs')->count())->toBe(1); // "other" is untouched
+
+    $audit = AuditEntry::query()->where('action', 'clear_queue')->latest('id')->first();
+    expect($audit)->not->toBeNull()
+        ->and($audit->user)->toBe('admin@test')
+        ->and($audit->subject)->toBe('database:default');
+});
+
+it('cancels selected pending jobs by id and audits it', function () {
+    config()->set('vigilance.control.enabled', true);
+    config()->set('queue.connections.database', ['driver' => 'database', 'table' => 'jobs', 'queue' => 'default']);
+    makeJobsTable();
+
+    $ids = [];
+    for ($i = 0; $i < 3; $i++) {
+        $ids[] = DB::table('jobs')->insertGetId([
+            'queue' => 'default', 'payload' => '{}', 'attempts' => 0,
+            'reserved_at' => null, 'available_at' => time(), 'created_at' => time(),
+        ]);
+    }
+
+    $deleted = app(QueueManager::class)->deletePending('database', [$ids[0], $ids[2]], 'admin@test');
+
+    expect($deleted)->toBe(2)
+        ->and(DB::table('jobs')->pluck('id')->all())->toBe([$ids[1]]);
+
+    expect(AuditEntry::query()->where('action', 'cancel_pending')->exists())->toBeTrue();
+});
+
+// ── Livewire wiring ──────────────────────────────────────────────────────────
+
+it('pauses and resumes a queue from the workload page', function () {
+    Vigilance::auth(fn () => true);
+
+    Livewire::test(Workload::class)->call('pauseQueue', 'database', 'emails', 15);
+    $paused = collect(app(ControlPlane::class)->pausedQueues())->firstWhere('queue', 'emails');
+    expect($paused)->not->toBeNull()
+        ->and($paused['expires_at'])->toBeGreaterThan(time());
+
+    Livewire::test(Workload::class)->call('resumeQueue', 'database', 'emails');
+    expect(app(ControlPlane::class)->isQueuePaused('database', 'emails'))->toBeFalse();
+});
+
+it('cancels pending jobs from the pending page when control is enabled', function () {
+    Vigilance::auth(fn () => true);
+    config()->set('vigilance.control.enabled', true);
+    config()->set('queue.connections.database', ['driver' => 'database', 'table' => 'jobs', 'queue' => 'default']);
+    makeJobsTable();
+
+    $id = DB::table('jobs')->insertGetId([
+        'queue' => 'default', 'payload' => '{}', 'attempts' => 0,
+        'reserved_at' => null, 'available_at' => time(), 'created_at' => time(),
+    ]);
+
+    Livewire::test(Pending::class)
+        ->set('selected', ['database#'.$id])
+        ->call('cancelSelected', 'database');
+
+    expect(DB::table('jobs')->where('id', $id)->exists())->toBeFalse();
+});

--- a/tests/Mcp/QueueControlToolsTest.php
+++ b/tests/Mcp/QueueControlToolsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Vigilance\Mcp\Tools\CancelPendingTool;
+use Vigilance\Mcp\Tools\ClearQueueTool;
+use Vigilance\Mcp\Tools\ControlWorkersTool;
+use Vigilance\Mcp\Tools\PauseQueueTool;
+use Vigilance\Mcp\Tools\ResumeQueueTool;
+use Vigilance\Supervision\ControlPlane;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    if (! Schema::hasTable('jobs')) {
+        Schema::create('jobs', function (Blueprint $t) {
+            $t->bigIncrements('id');
+            $t->string('queue')->index();
+            $t->longText('payload');
+            $t->unsignedTinyInteger('attempts');
+            $t->unsignedInteger('reserved_at')->nullable();
+            $t->unsignedInteger('available_at');
+            $t->unsignedInteger('created_at');
+        });
+    }
+
+    // DDL auto-commits on MySQL, so purge to keep row-count assertions
+    // deterministic across sqlite / mysql / postgres.
+    DB::table('jobs')->delete();
+});
+
+// ── gating ───────────────────────────────────────────────────────────────────
+
+it('refuses every worker/queue control tool when writes are disabled', function () {
+    config()->set('vigilance.mcp.allow_writes', false);
+    config()->set('vigilance.control.enabled', true);
+
+    $this->tool(ControlWorkersTool::class, ['action' => 'pause'])->assertHasErrors();
+    $this->tool(PauseQueueTool::class, ['queue' => 'emails'])->assertHasErrors();
+    $this->tool(ClearQueueTool::class, ['connection' => 'database', 'queue' => 'default'])->assertHasErrors();
+
+    expect(app(ControlPlane::class)->isPaused())->toBeFalse()
+        ->and(app(ControlPlane::class)->isQueuePaused('database', 'emails'))->toBeFalse();
+});
+
+it('refuses destructive tools when manual control is disabled even with writes on', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+    config()->set('vigilance.control.enabled', false);
+
+    $this->tool(ClearQueueTool::class, ['connection' => 'database', 'queue' => 'default'])->assertHasErrors();
+    $this->tool(CancelPendingTool::class, ['connection' => 'database', 'ids' => [1]])->assertHasErrors();
+});
+
+// ── fleet control ────────────────────────────────────────────────────────────
+
+it('pauses and resumes the whole fleet over mcp and audits it', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+
+    $this->tool(ControlWorkersTool::class, ['action' => 'pause'])->assertOk()->assertSee('paused');
+    expect(app(ControlPlane::class)->isPaused())->toBeTrue();
+
+    $this->tool(ControlWorkersTool::class, ['action' => 'resume'])->assertOk();
+    expect(app(ControlPlane::class)->status())->toBe(ControlPlane::RUNNING);
+
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'pause_workers', 'user' => 'mcp']);
+});
+
+it('restarts the fleet over mcp', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+
+    $this->tool(ControlWorkersTool::class, ['action' => 'restart'])->assertOk();
+
+    expect(app(ControlPlane::class)->restartToken())->not->toBeNull();
+});
+
+// ── per-queue control ────────────────────────────────────────────────────────
+
+it('pauses a single queue over mcp (timed) and resumes it', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+
+    $this->tool(PauseQueueTool::class, ['queue' => 'emails', 'connection' => 'redis', 'seconds' => 300])
+        ->assertOk()
+        ->assertSee('emails');
+
+    expect(app(ControlPlane::class)->isQueuePaused('redis', 'emails'))->toBeTrue();
+
+    $this->tool(ResumeQueueTool::class, ['queue' => 'emails', 'connection' => 'redis'])->assertOk();
+
+    expect(app(ControlPlane::class)->isQueuePaused('redis', 'emails'))->toBeFalse();
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'pause_queue', 'subject' => 'redis:emails']);
+});
+
+it('defaults the connection to vigilance.defaults.connection', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+    config()->set('vigilance.defaults.connection', 'sqs');
+
+    $this->tool(PauseQueueTool::class, ['queue' => 'jobs'])->assertOk();
+
+    expect(app(ControlPlane::class)->isQueuePaused('sqs', 'jobs'))->toBeTrue();
+});
+
+// ── destructive queue ops ────────────────────────────────────────────────────
+
+it('clears a queue over mcp when fully enabled', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+    config()->set('vigilance.control.enabled', true);
+    config()->set('queue.connections.database', ['driver' => 'database', 'table' => 'jobs', 'queue' => 'default']);
+
+    foreach (['default', 'default', 'other'] as $q) {
+        DB::table('jobs')->insert([
+            'queue' => $q, 'payload' => '{}', 'attempts' => 0,
+            'reserved_at' => null, 'available_at' => time(), 'created_at' => time(),
+        ]);
+    }
+
+    $this->tool(ClearQueueTool::class, ['connection' => 'database', 'queue' => 'default'])
+        ->assertOk()
+        ->assertSee('"deleted":2');
+
+    expect(DB::table('jobs')->count())->toBe(1);
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'clear_queue', 'subject' => 'database:default']);
+});
+
+it('cancels specific pending jobs over mcp', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+    config()->set('vigilance.control.enabled', true);
+    config()->set('queue.connections.database', ['driver' => 'database', 'table' => 'jobs', 'queue' => 'default']);
+
+    $ids = [];
+    for ($i = 0; $i < 3; $i++) {
+        $ids[] = DB::table('jobs')->insertGetId([
+            'queue' => 'default', 'payload' => '{}', 'attempts' => 0,
+            'reserved_at' => null, 'available_at' => time(), 'created_at' => time(),
+        ]);
+    }
+
+    $this->tool(CancelPendingTool::class, ['connection' => 'database', 'ids' => [$ids[0], $ids[2]]])
+        ->assertOk()
+        ->assertSee('"deleted":2');
+
+    expect(DB::table('jobs')->pluck('id')->all())->toBe([$ids[1]]);
+});


### PR DESCRIPTION
## Summary

Adds a **per-queue control plane** on top of the existing global worker controls, plus destructive queue operations and full MCP coverage — a driver-agnostic, production-first take on the queue-management ideas from the "new Horizon" work.

### Supervision — per-queue pause
- `ControlPlane` can pause/resume a single `connection:queue`, **timed or indefinite**, over the same cache-flag channel as the global pause (works on every driver + OS). Timed pauses auto-expire; per-queue pauses deliberately **survive a supervisor restart/deploy** until resumed or lapsed.
- The `Supervisor` narrows each pool to its still-active queues every tick: a `balance=false` pool serving several queues is relaunched bound to only its unpaused ones, and a fully-paused pool is held at zero workers without spinning workers up just to tear them down.

### Queue operations (`QueueManager` — gated by `control.enabled`, audited)
- **Clear a queue** — purge via Laravel's `ClearableQueue` (database / redis / sqs; beanstalkd/sync are rejected as unsupported).
- **Cancel pending jobs** — delete individual waiting jobs by id (database driver).

### Surfaces
- **CLI**: `vigilance:pause|continue --queue= [--connection=] [--for=]`; `vigilance:status` lists paused queues + expiry.
- **Dashboard**: Workload page gains per-queue Pause / 15m / 1h / Resume / Clear (+ a paused-but-idle strip); Pending page gains select + Cancel selected.
- **MCP** (full control): `control-workers`, `pause-queue`, `resume-queue`, `clear-queue`, `cancel-pending` — self-gate on `allow_writes`; the two destructive ones also require `control.enabled`; all audited. The `workers`/`queues` read tools now report control status + paused state.

### Safety
Destructive operations are double-gated (`VIGILANCE_CONTROL_ENABLED` + confirm dialog on the UI / `allow_writes` on MCP) and every mutation is written to the audit log, consistent with the existing manual-control surface.

## Verification
- Unit + Livewire + MCP + CLI tests, including deterministic partial-narrowing (`balance=false`) and full-pause cases.
- Verified **end-to-end with a real multi-process `vigilance:supervise` run** over a shared file sqlite: the active queue drains, the paused queue does not, and it drains again after resume.
- Full suite green on sqlite **and** MySQL 8 **and** Postgres 16; PHPStan clean; Pint clean. CSS build is a no-op (no new utility classes).

## Docs
CHANGELOG, README (supervision + MCP sections), `docs/mcp.md`, and inline `config/vigilance.php` comments updated.