### PR TITLE
Observability gap-closing pass (§1–§13)

### DIFF
--- a/"
+++ b/"
@@ -1,0 +1,1 @@
+563:            // per-metric "min_value" floor. Override "metrics" to watch your own.

--- a/"
+++ b/"
@@ -1,1 +1,0 @@
-563:            // per-metric "min_value" floor. Override "metrics" to watch your own.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+A broad gap-closing pass across the observability surface (error tracking,
+tracing, alerting, metrics, capture and the MCP server).
+
+### Added
+- **Breadcrumbs — the trail before an error.** A bounded, per-unit-of-work trail
+  (`Vigilance::breadcrumb()` + automatic log capture) attached to an issue,
+  latest-occurrence-wins like Sentry. Cleared at each request/job boundary;
+  rendered as a timeline on the issue page and surfaced via the MCP `issue` tool.
+  New `issues.breadcrumbs` config.
+- **Distributed trace propagation.** Continue an upstream trace from a W3C
+  `traceparent` header, carry it across the queue boundary onto dispatched jobs
+  (job links back to what enqueued it), and emit `traceparent` on outgoing HTTP
+  so downstream services join the trace. New `tracing.propagation` config.
+- **Manual issue merge.** Merge one issue into another when fingerprinting split
+  the same problem — occurrences/runs move to the canonical group, the source is
+  hidden, and future occurrences of its signature are redirected. From the issue
+  page or the `merge-issues` MCP tool.
+- **Maintenance windows.** Suppress alert notifications during planned
+  maintenance — ad-hoc (`vigilance:maintenance`) or recurring (config) — so a
+  deploy doesn't page anyone; the next cycle re-evaluates after it closes.
+  Also a `maintenance` MCP tool.
+- **First-class N+1 signal + alert.** N+1 patterns the tracer detects are
+  promoted to an aggregatable APM signal keyed by route/job, with a new
+  `long_running_job`- and `n_plus_one`-style opt-in alert rule.
+- **Long-running-job detection.** A rule that alerts on jobs stuck in "running"
+  past a threshold (runaway/stuck workers backlog/failure rules can't see).
+- **Richer custom metrics.** `Vigilance::histogram()` / `timing()` distributions
+  (avg, max, p50/p95/p99) and `decrement()`, on the dashboard and the MCP tool.
+- **User-feedback widget endpoint.** An opt-in public `POST {path}/feedback`
+  endpoint tying a user-reported problem to their trace; read via the `feedback`
+  MCP tool. New `feedback` config.
+- **Job capability tags.** Jobs are tagged `unique` / `encrypted` from their
+  queue contracts, so those traits are visible and filterable on the run.
+- **Retry lineage.** A manually retried run's `retry_of` is now actually set
+  (the marker was written at dispatch but never read), so retry chains show.
+- **New MCP tools.** `routes` (per-route p50/p95/p99), `workload` (system load +
+  job-class breakdown), `record-deploy`, `assign-issue`, plus the `maintenance`,
+  `merge-issues` and `feedback` tools above — closing dashboard/MCP parity.
+
+### Notes
+Deferred as out of scope for this pass (each for a concrete reason): continuous
+profiling and DOM session replay (need extra infrastructure), OTLP trace export
+(follow-up on the existing Ingest/TraceStorage seam), a slow-cache recorder
+(cache events carry no duration), custom-metric dimensional tags, job chain
+lineage (Laravel models no shared chain id), and deploy markers overlaid on
+charts. First-class batches (progress/cancel/retry) and log↔trace correlation
+already existed. Storage percentiles/aggregation remain sqlite/mysql/pgsql only.
+
 ## [0.7.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-23
+
 A broad gap-closing pass across the observability surface (error tracking,
 tracing, alerting, metrics, capture and the MCP server).
 
@@ -44,6 +46,19 @@ tracing, alerting, metrics, capture and the MCP server).
 - **New MCP tools.** `routes` (per-route p50/p95/p99), `workload` (system load +
   job-class breakdown), `record-deploy`, `assign-issue`, plus the `maintenance`,
   `merge-issues` and `feedback` tools above — closing dashboard/MCP parity.
+
+### Fixed
+Three defects surfaced by end-to-end testing against a real Laravel app:
+- **Outgoing `traceparent` was never emitted.** The registration guard probed
+  `method_exists()` on the Http *facade* (always false — the facade proxies via
+  `__callStatic`), so the global request middleware was never installed and
+  distributed propagation silently stopped at the app edge. Fixed.
+- **Encrypted jobs never got the `encrypted` tag.** Capability tags were derived
+  from the command object, which can't be reconstructed from an encrypted job's
+  opaque payload; they're now derived from the class name so the tag applies.
+- **Retry lineage emitted an `E_DEPRECATED`.** It stamped a dynamic property on
+  the job (fatal on PHP 9, and not a `Throwable` so the surrounding catch never
+  suppressed it); the parent run id now travels through the manual context.
 
 ### Notes
 Deferred as out of scope for this pass (each for a concrete reason): continuous

--- a/README.md
+++ b/README.md
@@ -23,15 +23,16 @@ See what ran — with the parameters it ran with — whether it failed, and **di
 | Scheduler monitoring | ❌ | partial | ✅ (late / failed / grace) |
 | Manual dispatch of jobs | ❌ | ❌ | ✅ (typed form from the constructor) |
 | Run arbitrary commands from UI | ❌ | ❌ | ✅ (allowlisted) |
-| Error tracking (grouped issues) | ❌ | ✅ (view) | ✅ (web · queue · command · browser, fingerprinted inbox) |
+| Error tracking (grouped issues) | ❌ | ✅ (view) | ✅ (web · queue · command · browser, fingerprinted inbox, **breadcrumbs**, manual merge) |
 | Whole-app APM + per-route percentiles | ❌ | ❌ | ✅ (p50/p95/p99, Apdex, error rate) |
 | Real User Monitoring (Core Web Vitals) | ❌ | ❌ | ✅ (LCP/INP/CLS/FCP/TTFB + JS errors) |
 | SLOs + error budgets | ❌ | ❌ | ✅ (burn-rate alerts) |
 | Trace-correlated log explorer | ❌ | ✅ (view) | ✅ (searchable, linked to traces) |
+| Distributed tracing | ❌ | ❌ | ✅ (W3C traceparent in/out + across the queue boundary) |
 | Custom business metrics | ❌ | ❌ | ✅ (one-line API + dashboard) |
 | Release health / deploy gating | ❌ | ❌ | ✅ (before/after regression guard + rollback alert) |
 | Anomaly detection | ❌ | ❌ | ✅ (dynamic baselines, not fixed thresholds) |
-| Alerting | ❌ | ❌ | ✅ (mail · Slack · Discord · Teams · webhooks + incidents) |
+| Alerting | ❌ | ❌ | ✅ (mail · Slack · Discord · Teams · webhooks + incidents + maintenance windows) |
 | **AI agent access (MCP)** | ❌ | ❌ | ✅ (query errors · APM · traces · releases · SLOs — read-only, with gated writes) |
 | Production-oriented | ✅ | ❌ (debug tool) | ✅ (see below) |
 
@@ -91,13 +92,13 @@ its own dashboard page. Full guide in
 
 | Feature | Page | What it gives you |
 |---|---|---|
-| **Issues** — unified error tracking | `/vigilance/issues` | Every exception (web · queue · command · `Vigilance::report()` · browser) fingerprinted into a grouped inbox with stacktrace, context, occurrence sparkline, assign/ack/mute/resolve |
+| **Issues** — unified error tracking | `/vigilance/issues` | Every exception (web · queue · command · `Vigilance::report()` · browser) fingerprinted into a grouped inbox with stacktrace, context, **breadcrumb trail**, occurrence sparkline, assign/ack/mute/resolve/**merge** |
 | **Routes** — per-route performance | `/vigilance/routes` | Throughput, error rate, Apdex and exact **p50/p95/p99** latency per route |
 | **Web Vitals** — RUM | `/vigilance/vitals` | Core Web Vitals (LCP/INP/CLS/FCP/TTFB) + JS errors from real visitors via the `@vigilanceRum` beacon |
 | **SLOs** — error budgets | `/vigilance/slos` | Availability / latency objectives vs. an error budget, with a short-window **burn-rate** alert |
 | **Incidents** — alerting depth | `/vigilance/incidents` | Fired alerts persisted as incidents (open → auto-resolved) with level, occurrences and **MTTR**; channels for Discord / Teams / generic webhooks |
 | **Releases** — deploy health | `/vigilance/releases` | Each deploy's error-rate / latency / throughput **after vs. before**, with a healthy/degraded/**regressed** verdict; a bad deploy fires a rollback-ready alert |
-| **Custom Metrics** — business KPIs | `/vigilance/custom-metrics` | `Vigilance::increment()` / `gauge()` → auto-discovered counter & gauge cards with sparklines |
+| **Custom Metrics** — business KPIs | `/vigilance/custom-metrics` | `Vigilance::increment()` / `gauge()` / `histogram()` → counter, gauge & **distribution** (p50/p95/p99) cards with sparklines |
 | **Logs** — explorer | `/vigilance/logs` | Searchable application logs **correlated to the trace that emitted them** |
 
 ```php
@@ -105,6 +106,8 @@ use Vigilance\Vigilance;
 
 Vigilance::increment('signups');                 // custom counter
 Vigilance::gauge('cart_value', $cart->total());  // custom gauge
+Vigilance::histogram('checkout_ms', $ms);        // distribution (p50/p95/p99)
+Vigilance::breadcrumb('Charged card', 'billing');// trail attached to the next error
 ```
 
 ```blade
@@ -159,9 +162,10 @@ The tool set mirrors **every dashboard page**, so the agent can reach anything y
 | Front-end (RUM) | `vitals` |
 | Tracing & logs | `traces` · `trace` · `logs` |
 | Reliability | `slos` · `incidents` · `releases` |
-| Queues & workers | `workers` (+ control status) · `queues` (+ paused state) · `pending` · `schedule` · `batches` · `tags` |
-| Business metrics | `custom-metrics` |
-| **Writes** (opt-in) | `resolve-issue` · `acknowledge-issue` · `mute-issue` · `reopen-issue` · `retry-run` · `retry-issue` |
+| Queues & workers | `workers` (+ control status) · `workload` · `queues` (+ paused state) · `routes` · `pending` · `schedule` · `batches` · `tags` |
+| Business metrics | `custom-metrics` (counters · gauges · distributions) |
+| Feedback | `feedback` (user-reported problems tied to a trace) |
+| **Writes** (opt-in) | `resolve-issue` · `acknowledge-issue` · `assign-issue` · `merge-issues` · `mute-issue` · `reopen-issue` · `retry-run` · `retry-issue` · `record-deploy` · `maintenance` |
 | **Worker & queue control** (opt-in) | `control-workers` · `pause-queue` · `resume-queue` · `clear-queue` · `cancel-pending` |
 | **Manual control** (opt-in, double-gated) | `dispatchable-jobs` · `runnable-commands` · `dispatch-job` · `run-command` |
 

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -469,6 +469,15 @@ return [
             // \Illuminate\Auth\AuthenticationException::class,
             // \Illuminate\Validation\ValidationException::class,
         ],
+
+        // Breadcrumbs: the trail of events leading up to an error, attached to the
+        // issue (latest occurrence wins). Add your own with
+        // Vigilance::breadcrumb('Charged card', 'billing', data: ['amount' => 20]).
+        'breadcrumbs' => [
+            'enabled' => true,
+            'log' => true, // auto-record application log lines as breadcrumbs
+            'max' => 25,   // ring-buffer size (oldest dropped)
+        ],
     ],
 
     /*

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -828,6 +828,11 @@ return [
     'tracing' => [
         'enabled' => env('VIGILANCE_TRACING', false),
 
+        // Distributed tracing: continue an upstream trace from an incoming W3C
+        // "traceparent" header, carry it across the queue boundary onto dispatched
+        // jobs, and emit it on outgoing HTTP so downstream services join the trace.
+        'propagation' => env('VIGILANCE_TRACING_PROPAGATION', true),
+
         'sample_rate' => env('VIGILANCE_TRACING_SAMPLE', 0),
 
         'slow_threshold' => (int) env('VIGILANCE_TRACING_SLOW', 1000),

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -413,6 +413,18 @@ return [
         // Generic webhook(s) — each receives the alert as JSON (PagerDuty, Opsgenie, …).
         'webhooks' => env('VIGILANCE_ALERT_WEBHOOKS'),
 
+        // Cache store backing the ad-hoc maintenance window (null = default).
+        'cache_store' => null,
+
+        // Recurring maintenance windows during which alert notifications are
+        // suppressed (rules still run on the dashboard, they just don't page).
+        // Each: ['days' => ['sat','sun'], 'from' => '02:00', 'to' => '04:00'].
+        // "days" optional (every day); "to" <= "from" wraps past midnight. Open
+        // an ad-hoc window around a deploy with `php artisan vigilance:maintenance`.
+        'maintenance' => [
+            // ['days' => ['sun'], 'from' => '02:00', 'to' => '03:00'],
+        ],
+
         'long_wait_seconds' => env('VIGILANCE_LONG_WAIT_SECONDS', 60),
         'throttle_minutes' => 15,
     ],

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -539,6 +539,9 @@ return [
 
         'rules' => [
             'queue_long_wait' => ['enabled' => true, 'seconds' => (int) env('VIGILANCE_LONG_WAIT_SECONDS', 60)],
+            // Jobs stuck in "running" longer than this. Off by default — set the
+            // threshold above your longest legitimate job before enabling.
+            'long_running_job' => ['enabled' => false, 'seconds' => (int) env('VIGILANCE_LONG_JOB_SECONDS', 300), 'limit' => 10],
             'error_rate' => ['enabled' => true, 'min_runs' => 20, 'percent' => 20],
             'exception_spike' => ['enabled' => true, 'count' => 50],
             'slow_request_rate' => ['enabled' => false, 'count' => 100],

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -504,6 +504,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User feedback
+    |--------------------------------------------------------------------------
+    |
+    | An opt-in public endpoint (POST {path}/feedback) for a "report a problem"
+    | widget: users describe an issue even when nothing crashed, captured tied to
+    | the trace they were on so the complaint links to the telemetry. Read it back
+    | via the "feedback" MCP tool. Strictly capped; throttled per IP.
+    |
+    */
+
+    'feedback' => [
+        'enabled' => (bool) env('VIGILANCE_FEEDBACK', false),
+        'throttle' => env('VIGILANCE_FEEDBACK_THROTTLE', '30,1'),
+        'max_length' => 2000,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Service Level Objectives (SLOs)
     |--------------------------------------------------------------------------
     |

--- a/config/vigilance.php
+++ b/config/vigilance.php
@@ -542,6 +542,8 @@ return [
             // Jobs stuck in "running" longer than this. Off by default — set the
             // threshold above your longest legitimate job before enabling.
             'long_running_job' => ['enabled' => false, 'seconds' => (int) env('VIGILANCE_LONG_JOB_SECONDS', 300), 'limit' => 10],
+            // N+1 query patterns promoted from traces. Off by default.
+            'n_plus_one' => ['enabled' => false, 'min_occurrences' => 5, 'window' => '1h'],
             'error_rate' => ['enabled' => true, 'min_runs' => 20, 'percent' => 20],
             'exception_spike' => ['enabled' => true, 'count' => 50],
             'slow_request_rate' => ['enabled' => false, 'count' => 100],

--- a/database/migrations/2026_07_23_000001_add_merged_into_to_failure_groups.php
+++ b/database/migrations/2026_07_23_000001_add_merged_into_to_failure_groups.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function connection(): ?string
+    {
+        return config('vigilance.storage.connection') ?: config('database.default');
+    }
+
+    public function up(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        if ($schema->hasColumn('vigilance_failure_groups', 'merged_into')) {
+            return;
+        }
+
+        $schema->table('vigilance_failure_groups', function (Blueprint $table) {
+            // Set when an issue is manually merged into another (its canonical
+            // group). Merged issues are hidden from the inbox and new occurrences
+            // of their signature are redirected to the target.
+            $table->unsignedBigInteger('merged_into')->nullable()->index()->after('resolved_at');
+        });
+    }
+
+    public function down(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        if ($schema->hasColumn('vigilance_failure_groups', 'merged_into')) {
+            $schema->table('vigilance_failure_groups', function (Blueprint $table) {
+                $table->dropColumn('merged_into');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_23_000002_create_vigilance_user_feedback.php
+++ b/database/migrations/2026_07_23_000002_create_vigilance_user_feedback.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function connection(): ?string
+    {
+        return config('vigilance.storage.connection') ?: config('database.default');
+    }
+
+    public function up(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        if ($schema->hasTable('vigilance_user_feedback')) {
+            return;
+        }
+
+        $schema->create('vigilance_user_feedback', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->text('message');
+            $table->string('email')->nullable();
+            $table->string('name')->nullable();
+            $table->string('url')->nullable();
+            $table->string('trace_id', 36)->nullable()->index();
+            $table->string('user')->nullable();
+            $table->timestamp('created_at')->nullable()->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection($this->connection())->dropIfExists('vigilance_user_feedback');
+    }
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
       <div class="card reveal">
         <div class="card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></div>
         <h3>Request &amp; job tracing</h3>
-        <p>Per-request / per-job waterfalls of every query, cache op and outgoing call — with N+1 detection. Tail-sampled: only slow or failed traces are stored.</p>
+        <p>Per-request / per-job waterfalls of every query, cache op and outgoing call — with N+1 detection and <strong>distributed W3C traceparent</strong> propagation across HTTP and the queue boundary. Only slow or failed traces are stored.</p>
       </div>
 
       <div class="card reveal">
@@ -177,7 +177,7 @@
       <div class="card reveal">
         <div class="card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="m21.7 18-8-14a2 2 0 0 0-3.5 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.7-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg></div>
         <h3>Error tracking &amp; alerts</h3>
-        <p>A fingerprinted <strong>Issues</strong> inbox over every layer — web, queue, command and browser errors — with stacktraces and context. Rule-based alerts route to mail / Slack / Discord / Teams / webhooks, persisted as incidents with MTTR.</p>
+        <p>A fingerprinted <strong>Issues</strong> inbox over every layer — web, queue, command and browser errors — with stacktraces, context and a <strong>breadcrumb trail</strong>, plus manual issue merge. Rule-based alerts (with maintenance windows) route to mail / Slack / Discord / Teams / webhooks, persisted as incidents with MTTR.</p>
       </div>
 
       <div class="card reveal">

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -95,10 +95,13 @@ server with `laravel/mcp`'s inspector: `php artisan mcp:inspector vigilance`.
 | `incidents` | Fired alerts as incidents (open/resolved, occurrences, MTTR). |
 | `releases` | Per-deploy health: error-rate / latency / throughput after vs. before, with a verdict. |
 | `vitals` | Real User Monitoring — Core Web Vitals (p75 LCP/INP/CLS/FCP/TTFB) per page, with ratings. |
-| `custom-metrics` | Custom counters & gauges from `Vigilance::increment()` / `gauge()`. |
-| `workers` | The supervisor/worker fleet across nodes (the Horizon-replacement view). |
-| `queues` | Per-queue depth, worker count, throughput, wait and time-to-clear. |
+| `custom-metrics` | Custom counters, gauges & distributions (p50/p95/p99) from `Vigilance::increment()` / `gauge()` / `histogram()`. |
+| `routes` | Per-route HTTP performance: p50/p95/p99, Apdex, error rate over a window. |
+| `workers` | The supervisor/worker fleet across nodes (the Horizon-replacement view) + control status. |
+| `workload` | System load average + per-job-class breakdown (runs, failures, runtime). |
+| `queues` | Per-queue depth, worker count, throughput, wait and time-to-clear (+ paused state). |
 | `pending` | Jobs currently waiting in the (database) queue backend. |
+| `feedback` | Recent user-reported feedback from the widget, tied to the trace the user was on. |
 | `job-metrics` | Per-job-class run counts, failures, duration and memory/CPU. |
 | `schedule` | Scheduled-task monitors: cron, last run, and late/failed flags. |
 | `batches` | Job batches (Laravel bus batches) with progress. |
@@ -114,9 +117,13 @@ are **not even listed** to the client, so the agent cannot call them.
 | `resolve-issue` | Mark an issue resolved. |
 | `reopen-issue` | Reopen a resolved issue. |
 | `acknowledge-issue` | Acknowledge an issue and assign it to the MCP actor. |
+| `assign-issue` | Assign an issue to an arbitrary owner (or unassign). |
+| `merge-issues` | Merge one issue into another (occurrences/runs move; source hidden). |
 | `mute-issue` | Mute an issue for N hours. |
 | `retry-run` | Retry one failed queued job. |
 | `retry-issue` | Retry every failed job in an issue, then resolve it. |
+| `record-deploy` | Record a deployment marker for release-health correlation. |
+| `maintenance` | Start / stop / status an alert-suppression maintenance window. |
 
 Every write is written to Vigilance's **audit log** (`vigilance_audit`), attributed
 to `mcp` (or `mcp:<user>` over an authenticated web transport) — exactly like a

--- a/resources/views/pages/custom-metrics.blade.php
+++ b/resources/views/pages/custom-metrics.blade.php
@@ -38,15 +38,27 @@
                 <div class="v-card v-card--pad space-y-2">
                     <div class="flex items-baseline justify-between gap-2">
                         <h2 class="truncate font-mono font-semibold v-strong" title="{{ $metric->name }}">{{ $metric->name }}</h2>
-                        <span class="v-pill is-neutral">{{ $metric->type === 'count' ? 'counter' : 'gauge' }}</span>
+                        <span class="v-pill is-neutral">{{ ['count' => 'counter', 'value' => 'gauge', 'distribution' => 'distribution'][$metric->type] ?? $metric->type }}</span>
                     </div>
 
                     <div class="flex items-baseline gap-2">
                         <span class="text-3xl font-semibold v-strong v-num">{{ number_format($metric->value) }}</span>
                         <span class="text-[11px] v-faint">
-                            {{ $metric->type === 'count' ? number_format($metric->peak).' events' : 'peak '.number_format($metric->peak) }}
+                            @switch($metric->type)
+                                @case('count') {{ number_format($metric->peak) }} events @break
+                                @case('distribution') avg · peak {{ number_format($metric->peak) }} @break
+                                @default peak {{ number_format($metric->peak) }}
+                            @endswitch
                         </span>
                     </div>
+
+                    @if ($metric->type === 'distribution')
+                        <div class="flex gap-3 text-[11px] v-muted font-mono">
+                            <span>p50 <span class="v-strong v-num">{{ $metric->p50 ?? '—' }}</span></span>
+                            <span>p95 <span class="v-strong v-num">{{ $metric->p95 ?? '—' }}</span></span>
+                            <span>p99 <span class="v-strong v-num">{{ $metric->p99 ?? '—' }}</span></span>
+                        </div>
+                    @endif
 
                     <svg viewBox="0 0 {{ $sw }} {{ $sh }}" preserveAspectRatio="none" class="h-11 w-full" aria-hidden="true">
                         @if ($path)

--- a/resources/views/pages/issue-detail.blade.php
+++ b/resources/views/pages/issue-detail.blade.php
@@ -30,6 +30,10 @@
             @else
                 <button type="button" wire:click="resolve" class="v-btn v-btn--sm v-btn--primary">Resolve</button>
             @endif
+            <form wire:submit.prevent="merge" class="flex items-center gap-1">
+                <input type="number" min="1" wire:model="mergeInto" placeholder="Merge into #" class="v-select v-btn--sm w-28" aria-label="Merge into issue id">
+                <button type="submit" class="v-btn v-btn--sm v-btn--ghost">Merge</button>
+            </form>
         </div>
     </div>
 

--- a/resources/views/pages/issue-detail.blade.php
+++ b/resources/views/pages/issue-detail.blade.php
@@ -53,17 +53,53 @@
         </div>
     @endif
 
-    @if (! empty($issue->context))
+    @php $breadcrumbs = $issue->context['breadcrumbs'] ?? []; @endphp
+
+    @if (! empty(array_diff_key((array) $issue->context, ['breadcrumbs' => true])))
         <div class="v-card">
             <div class="v-card__header"><h2 class="v-card__title">Context</h2></div>
             <dl class="grid grid-cols-1 gap-x-6 gap-y-2 p-4 sm:grid-cols-2">
                 @foreach ($issue->context as $key => $value)
+                    @continue($key === 'breadcrumbs')
                     <div class="flex gap-3">
                         <dt class="v-stat__label w-20 shrink-0">{{ $key }}</dt>
                         <dd class="min-w-0 break-words font-mono text-[12px] v-muted">{{ is_array($value) ? json_encode($value) : $value }}</dd>
                     </div>
                 @endforeach
             </dl>
+        </div>
+    @endif
+
+    @if (! empty($breadcrumbs))
+        <div class="v-card overflow-hidden">
+            <div class="v-card__header">
+                <h2 class="v-card__title">Breadcrumbs</h2>
+                <span class="text-[10px] uppercase tracking-wide v-faint">trail before the error</span>
+            </div>
+            <ol class="divide-y">
+                @foreach ($breadcrumbs as $crumb)
+                    @php
+                        $lvl = strtolower($crumb['level'] ?? 'info');
+                        $tone = match ($lvl) {
+                            'error', 'critical', 'alert', 'emergency' => 'is-danger',
+                            'warning' => 'is-warn',
+                            'debug' => 'is-neutral',
+                            default => 'is-info',
+                        };
+                    @endphp
+                    <li class="flex items-start gap-3 px-4 py-2 text-[12px]">
+                        <span class="v-pill {{ $tone }} shrink-0 uppercase tracking-wide">{{ $lvl }}</span>
+                        @if (! empty($crumb['category']))
+                            <span class="shrink-0 font-mono v-faint">{{ $crumb['category'] }}</span>
+                        @endif
+                        <span class="min-w-0 break-words v-strong">{{ $crumb['message'] ?? '' }}</span>
+                        @if (! empty($crumb['data']))
+                            <span class="min-w-0 break-words font-mono v-muted">{{ json_encode($crumb['data']) }}</span>
+                        @endif
+                        <span class="ml-auto shrink-0 font-mono v-faint">{{ \Illuminate\Support\Str::after((string) ($crumb['t'] ?? ''), 'T') }}</span>
+                    </li>
+                @endforeach
+            </ol>
         </div>
     @endif
 

--- a/src/Capture/FailureGrouper.php
+++ b/src/Capture/FailureGrouper.php
@@ -51,6 +51,15 @@ class FailureGrouper
 
         $isNew = $group->wasRecentlyCreated;
 
+        // If this signature was manually merged into another issue, redirect the
+        // occurrence to the canonical group so the two never diverge again.
+        if ($group->merged_into !== null && ! $isNew) {
+            $target = FailureGroup::query()->whereKey($group->merged_into)->first();
+            if ($target !== null) {
+                $group = $target;
+            }
+        }
+
         // Latest-wins metadata (sample / request context / regression re-open).
         // A race here only changes which sample is kept — never the count — so
         // the model save is fine. Crucially it does NOT touch "occurrences": a

--- a/src/Capture/IssueCapture.php
+++ b/src/Capture/IssueCapture.php
@@ -4,6 +4,7 @@ namespace Vigilance\Capture;
 
 use Illuminate\Support\Str;
 use Throwable;
+use Vigilance\Support\Breadcrumbs;
 use Vigilance\Support\PathMatcher;
 use Vigilance\Support\Redactor;
 use Vigilance\Vigilance;
@@ -124,6 +125,9 @@ class IssueCapture
             }
         }
 
-        return array_filter($context, static fn ($v): bool => $v !== null && $v !== '');
+        $context = array_filter($context, static fn ($v): bool => $v !== null && $v !== '');
+
+        // The trail of events (logs + manual breadcrumbs) leading up to the error.
+        return array_merge($context, app(Breadcrumbs::class)->contextFragment());
     }
 }

--- a/src/Capture/Recorder.php
+++ b/src/Capture/Recorder.php
@@ -12,6 +12,7 @@ use Vigilance\Contracts\RunRepository;
 use Vigilance\Data\RunData;
 use Vigilance\Enums\RunStatus;
 use Vigilance\Enums\RunType;
+use Vigilance\Support\Breadcrumbs;
 use Vigilance\Support\Redactor;
 use Vigilance\Vigilance;
 
@@ -282,6 +283,8 @@ class Recorder
                 $class,
                 get_class($exception),
                 $exception->getMessage(),
+                source: RunType::Job->value,
+                context: app(Breadcrumbs::class)->contextFragment(),
             );
 
             $changes = RunData::make([

--- a/src/Capture/Recorder.php
+++ b/src/Capture/Recorder.php
@@ -89,12 +89,12 @@ class Recorder
                 'caused_by' => $manual['user'] ?? null,
             ])->type(RunType::Job)->status(RunStatus::Queued);
 
-            // Retry lineage: a manual retry (JobRetrier) tags the job object with
-            // the id of the run it re-dispatches. At createPayloadUsing time
-            // commandName is still that raw object, so we can read it back and
-            // link the fresh run to its parent.
-            if (is_object($commandName) && ($retryOf = static::readRetryOf($commandName)) !== null) {
-                $data->set('retry_of', $retryOf);
+            // Retry lineage: a manual retry (JobRetrier) dispatches within a
+            // manual context carrying the id of the run it re-dispatches, so the
+            // fresh run links back to its parent — without stamping a dynamic
+            // property on the job (deprecated on PHP 8.2+, fatal on 9).
+            if (($retryOf = $manual['retry_of'] ?? null) !== null) {
+                $data->set('retry_of', (int) $retryOf);
             }
 
             if (config('vigilance.capture.store_for_retry', true)) {
@@ -125,26 +125,6 @@ class Recorder
                 $traceparent !== null ? ['vigilance_traceparent' => $traceparent] : [],
             );
         }) ?? [];
-    }
-
-    /**
-     * Read the retry-lineage marker JobRetrier stamps on a re-dispatched job
-     * ($job->vigilanceRetryOf = originalRunId). Null-safe for jobs that never
-     * carry it or forbid dynamic properties.
-     */
-    protected static function readRetryOf(object $command): ?int
-    {
-        try {
-            $value = $command->vigilanceRetryOf ?? null;
-
-            return match (true) {
-                is_int($value) => $value,
-                is_string($value) && ctype_digit($value) => (int) $value,
-                default => null,
-            };
-        } catch (\Throwable) {
-            return null;
-        }
     }
 
     public function jobProcessing(JobProcessing $event): void
@@ -457,7 +437,12 @@ class Recorder
         $command = PayloadExtractor::command($payload);
 
         if (! $command) {
-            return [null, []];
+            // The command object couldn't be reconstructed (e.g. an encrypted
+            // job's opaque payload). We still know its class, so surface at least
+            // the capability tags derived from the class name.
+            $class = $payload['data']['commandName'] ?? null;
+
+            return [null, TagExtractor::forClass(is_string($class) ? $class : null)];
         }
 
         return [

--- a/src/Capture/Recorder.php
+++ b/src/Capture/Recorder.php
@@ -14,6 +14,7 @@ use Vigilance\Enums\RunStatus;
 use Vigilance\Enums\RunType;
 use Vigilance\Support\Breadcrumbs;
 use Vigilance\Support\Redactor;
+use Vigilance\Tracing\Tracer;
 use Vigilance\Vigilance;
 
 class Recorder
@@ -114,9 +115,14 @@ class Recorder
                 $this->runs->insert($data);
             }
 
+            // Carry the in-flight trace across the queue boundary so the job
+            // links back to the request/job that dispatched it.
+            $traceparent = app(Tracer::class)->traceparent();
+
             return array_merge(
                 ['vigilance_keep' => $keep ? 1 : 0],
                 $injectUuid ? ['uuid' => $uuid] : [],
+                $traceparent !== null ? ['vigilance_traceparent' => $traceparent] : [],
             );
         }) ?? [];
     }

--- a/src/Capture/Recorder.php
+++ b/src/Capture/Recorder.php
@@ -87,6 +87,14 @@ class Recorder
                 'caused_by' => $manual['user'] ?? null,
             ])->type(RunType::Job)->status(RunStatus::Queued);
 
+            // Retry lineage: a manual retry (JobRetrier) tags the job object with
+            // the id of the run it re-dispatches. At createPayloadUsing time
+            // commandName is still that raw object, so we can read it back and
+            // link the fresh run to its parent.
+            if (is_object($commandName) && ($retryOf = static::readRetryOf($commandName)) !== null) {
+                $data->set('retry_of', $retryOf);
+            }
+
             if (config('vigilance.capture.store_for_retry', true)) {
                 $command = $payload['data']['command'] ?? null;
                 $data->set('payload_raw', match (true) {
@@ -110,6 +118,26 @@ class Recorder
                 $injectUuid ? ['uuid' => $uuid] : [],
             );
         }) ?? [];
+    }
+
+    /**
+     * Read the retry-lineage marker JobRetrier stamps on a re-dispatched job
+     * ($job->vigilanceRetryOf = originalRunId). Null-safe for jobs that never
+     * carry it or forbid dynamic properties.
+     */
+    protected static function readRetryOf(object $command): ?int
+    {
+        try {
+            $value = $command->vigilanceRetryOf ?? null;
+
+            return match (true) {
+                is_int($value) => $value,
+                is_string($value) && ctype_digit($value) => (int) $value,
+                default => null,
+            };
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     public function jobProcessing(JobProcessing $event): void

--- a/src/Capture/TagExtractor.php
+++ b/src/Capture/TagExtractor.php
@@ -2,6 +2,8 @@
 
 namespace Vigilance\Capture;
 
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -27,6 +29,7 @@ class TagExtractor
         }
 
         $tags = array_merge($tags, static::modelsFor($command));
+        $tags = array_merge($tags, static::capabilitiesFor($command));
 
         if ($queue) {
             $tags[] = 'queue:'.$queue;
@@ -36,6 +39,30 @@ class TagExtractor
             fn ($tag) => Str::limit((string) $tag, 80, ''),
             array_filter($tags)
         )));
+    }
+
+    /**
+     * Surface a job's queue capabilities as tags so they're visible and
+     * filterable on the run (properties like these are otherwise skipped by the
+     * payload extractor): "unique" for ShouldBeUnique(-UntilProcessing) and
+     * "encrypted" for ShouldBeEncrypted.
+     *
+     * @return list<string>
+     */
+    protected static function capabilitiesFor(object $command): array
+    {
+        $tags = [];
+
+        // ShouldBeUniqueUntilProcessing extends ShouldBeUnique, so this covers both.
+        if ($command instanceof ShouldBeUnique) {
+            $tags[] = 'unique';
+        }
+
+        if ($command instanceof ShouldBeEncrypted) {
+            $tags[] = 'encrypted';
+        }
+
+        return $tags;
     }
 
     /** @return list<string> */

--- a/src/Capture/TagExtractor.php
+++ b/src/Capture/TagExtractor.php
@@ -42,23 +42,36 @@ class TagExtractor
     }
 
     /**
-     * Surface a job's queue capabilities as tags so they're visible and
-     * filterable on the run (properties like these are otherwise skipped by the
-     * payload extractor): "unique" for ShouldBeUnique(-UntilProcessing) and
-     * "encrypted" for ShouldBeEncrypted.
-     *
      * @return list<string>
      */
     protected static function capabilitiesFor(object $command): array
     {
+        return static::forClass($command::class);
+    }
+
+    /**
+     * Surface a job's queue capabilities as tags from its class name alone —
+     * "unique" for ShouldBeUnique(-UntilProcessing), "encrypted" for
+     * ShouldBeEncrypted. Class-based (not object-based) so it still works for
+     * encrypted jobs, whose command object cannot be reconstructed at capture
+     * time (the payload is opaque) — the one case that most needs the tag.
+     *
+     * @return list<string>
+     */
+    public static function forClass(?string $class): array
+    {
+        if ($class === null || ! class_exists($class)) {
+            return [];
+        }
+
         $tags = [];
 
         // ShouldBeUniqueUntilProcessing extends ShouldBeUnique, so this covers both.
-        if ($command instanceof ShouldBeUnique) {
+        if (is_a($class, ShouldBeUnique::class, true)) {
             $tags[] = 'unique';
         }
 
-        if ($command instanceof ShouldBeEncrypted) {
+        if (is_a($class, ShouldBeEncrypted::class, true)) {
             $tags[] = 'encrypted';
         }
 

--- a/src/Console/MaintenanceCommand.php
+++ b/src/Console/MaintenanceCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Vigilance\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Vigilance\Notifications\MaintenanceWindow;
+
+class MaintenanceCommand extends Command
+{
+    protected $signature = 'vigilance:maintenance
+        {--minutes=30 : Open an ad-hoc maintenance window for this many minutes}
+        {--off : Close the ad-hoc maintenance window now}
+        {--status : Show whether alert notifications are currently suppressed}';
+
+    protected $description = 'Suppress alert notifications during planned maintenance (e.g. around a deploy).';
+
+    public function handle(MaintenanceWindow $maintenance): int
+    {
+        if ($this->option('off')) {
+            $maintenance->stop();
+            $this->components->info('Maintenance window closed — alerting resumes.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('status')) {
+            $until = $maintenance->adHocUntil();
+            $this->components->twoColumnDetail(
+                'Alert notifications',
+                $maintenance->active() ? '<fg=yellow>suppressed</>' : '<fg=green>active</>',
+            );
+            if ($until !== null) {
+                $this->components->twoColumnDetail('Ad-hoc window until', Carbon::createFromTimestamp($until)->toDateTimeString());
+            }
+
+            return self::SUCCESS;
+        }
+
+        $minutes = max(1, (int) $this->option('minutes'));
+        $until = $maintenance->start($minutes);
+
+        $this->components->info("Maintenance window open for {$minutes} min (until ".Carbon::createFromTimestamp($until)->toTimeString().') — alerts suppressed.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Control/IssueMerger.php
+++ b/src/Control/IssueMerger.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Vigilance\Control;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Vigilance\Models\FailureGroup;
+use Vigilance\Models\Run;
+
+/**
+ * Manually merge one error issue into another when the automatic fingerprinting
+ * split what is really the same problem. The source's occurrences and runs move
+ * to the target, the source is marked merged (and hidden from the inbox), and
+ * future occurrences of the source's signature are redirected to the target by
+ * FailureGrouper.
+ */
+class IssueMerger
+{
+    public function __construct(protected AuditLogger $audit = new AuditLogger) {}
+
+    /**
+     * @return array{merged_into: int, moved_runs: int, occurrences: int}
+     */
+    public function merge(int $fromId, int $intoId, ?string $user = null): array
+    {
+        if ($fromId === $intoId) {
+            throw new \InvalidArgumentException('An issue cannot be merged into itself.');
+        }
+
+        $from = FailureGroup::query()->whereKey($fromId)->first();
+        $into = FailureGroup::query()->whereKey($intoId)->first();
+
+        if ($from === null || $into === null) {
+            throw new \InvalidArgumentException('Both the source and target issue must exist.');
+        }
+
+        // Resolve the target through any existing merge chain so we never point
+        // at an already-merged group.
+        $seen = [];
+        while ($into->merged_into !== null && ! in_array($into->id, $seen, true)) {
+            $seen[] = $into->id;
+            $into = FailureGroup::query()->whereKey($into->merged_into)->first() ?? $into;
+        }
+
+        if ($from->id === $into->id) {
+            throw new \InvalidArgumentException('The issues are already merged together.');
+        }
+
+        $movedRuns = Run::query()->where('failure_group_id', $from->id)->update(['failure_group_id' => $into->id]);
+
+        FailureGroup::query()->whereKey($into->id)->update([
+            'occurrences' => DB::raw('occurrences + '.(int) $from->occurrences),
+            'last_seen_at' => $into->last_seen_at !== null && $from->last_seen_at !== null
+                ? max($into->last_seen_at, $from->last_seen_at)
+                : ($from->last_seen_at ?? $into->last_seen_at),
+        ]);
+
+        $from->forceFill([
+            'merged_into' => $into->id,
+            'resolved_at' => $from->resolved_at ?? Carbon::now(),
+        ])->save();
+
+        $this->audit->log(
+            action: 'merge_issue',
+            subject: (string) $from->id,
+            meta: ['from' => $from->id, 'into' => $into->id, 'moved_runs' => $movedRuns, 'occurrences' => (int) $from->occurrences],
+            user: $user,
+        );
+
+        return ['merged_into' => (int) $into->id, 'moved_runs' => (int) $movedRuns, 'occurrences' => (int) $from->occurrences];
+    }
+}

--- a/src/Control/JobRetrier.php
+++ b/src/Control/JobRetrier.php
@@ -116,8 +116,10 @@ class JobRetrier
     {
         $job = $this->restore($run);
 
-        // Tag the lineage. The capture layer does not yet read this property,
-        // so we also record the linkage in the audit trail.
+        // Tag the lineage: the capture layer reads this back at dispatch time
+        // (Recorder::onJobPayloadCreate) and links the fresh run's retry_of to
+        // this run. The audit trail records it too, as a fallback for jobs that
+        // forbid dynamic properties.
         try {
             $job->vigilanceRetryOf = $run->id;
         } catch (\Throwable) {

--- a/src/Control/JobRetrier.php
+++ b/src/Control/JobRetrier.php
@@ -116,16 +116,9 @@ class JobRetrier
     {
         $job = $this->restore($run);
 
-        // Tag the lineage: the capture layer reads this back at dispatch time
-        // (Recorder::onJobPayloadCreate) and links the fresh run's retry_of to
-        // this run. The audit trail records it too, as a fallback for jobs that
-        // forbid dynamic properties.
-        try {
-            $job->vigilanceRetryOf = $run->id;
-        } catch (\Throwable) {
-            // Some jobs may forbid dynamic properties; lineage stays in audit.
-        }
-
+        // Re-dispatch inside a manual context carrying the parent run id, which
+        // the capture layer reads at createPayloadUsing time to set the fresh
+        // run's retry_of — no dynamic property on the job (deprecated on 8.2+).
         Vigilance::asManual($user, function () use ($job, $run) {
             $pending = dispatch($job);
 
@@ -136,7 +129,7 @@ class JobRetrier
             if ($run->connection_name) {
                 $pending->onConnection($run->connection_name);
             }
-        });
+        }, retryOf: $run->id);
     }
 
     /**

--- a/src/Http/Controllers/FeedbackController.php
+++ b/src/Http/Controllers/FeedbackController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Vigilance\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Vigilance\Models\UserFeedback;
+use Vigilance\Tracing\Tracer;
+use Vigilance\Vigilance;
+
+/**
+ * Public (unauthenticated, throttled) endpoint for the user-feedback widget:
+ * a user reports a problem even when nothing crashed, and it's stored tied to
+ * the trace they were on so the complaint links to the technical telemetry.
+ * Opt-in (vigilance.feedback.enabled). Strictly validated and capped so an open
+ * endpoint can't be used to flood storage.
+ */
+class FeedbackController
+{
+    public function store(Request $request, Tracer $tracer): Response
+    {
+        abort_unless((bool) config('vigilance.feedback.enabled', false), 404);
+
+        $message = trim((string) $request->input('message', ''));
+
+        if ($message === '') {
+            return response()->noContent(); // nothing to record; never error the widget
+        }
+
+        try {
+            UserFeedback::query()->create([
+                'message' => Str::limit($message, (int) config('vigilance.feedback.max_length', 2000), ''),
+                'email' => $this->clean($request->input('email'), 200),
+                'name' => $this->clean($request->input('name'), 120),
+                'url' => $this->clean($request->input('url') ?? $request->headers->get('referer'), 500),
+                'trace_id' => $this->clean($request->input('trace_id') ?? $tracer->currentTraceId(), 36),
+                'user' => Vigilance::currentUser($request),
+                'created_at' => Carbon::now(),
+            ]);
+        } catch (\Throwable) {
+            // Capturing feedback must never surface an error to the end user.
+        }
+
+        return response()->noContent();
+    }
+
+    protected function clean(mixed $value, int $max): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return Str::limit(trim($value), $max, '');
+    }
+}

--- a/src/Http/Livewire/Failures.php
+++ b/src/Http/Livewire/Failures.php
@@ -112,6 +112,7 @@ class Failures extends Component
     public function render()
     {
         $groups = FailureGroup::query()
+            ->whereNull('merged_into') // merged issues live under their canonical group
             ->when($this->tab === 'open', fn ($query) => $query->whereNull('resolved_at'))
             ->when($this->tab === 'resolved', fn ($query) => $query->whereNotNull('resolved_at'))
             ->when($this->source !== '', fn ($query) => $query->where('source', $this->source))

--- a/src/Http/Livewire/IssueDetail.php
+++ b/src/Http/Livewire/IssueDetail.php
@@ -4,6 +4,7 @@ namespace Vigilance\Http\Livewire;
 
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Vigilance\Control\IssueMerger;
 use Vigilance\Control\JobRetrier;
 use Vigilance\Models\FailureGroup;
 use Vigilance\Models\Run;
@@ -70,6 +71,34 @@ class IssueDetail extends Component
         $result = app(JobRetrier::class)->retryGroup($this->issueId, Vigilance::currentUser());
 
         $this->flash("Retried {$result['retried']} job(s)".($result['skipped'] > 0 ? ", {$result['skipped']} skipped (no stored payload)" : '').'.');
+    }
+
+    public string $mergeInto = '';
+
+    /**
+     * Merge this issue into another (by id) when fingerprinting split the same
+     * problem in two — occurrences/runs move to the target, this one is hidden.
+     */
+    public function merge(): void
+    {
+        $target = (int) trim($this->mergeInto);
+
+        if ($target <= 0) {
+            $this->flash('Enter the target issue id to merge into.');
+
+            return;
+        }
+
+        try {
+            $result = app(IssueMerger::class)->merge($this->issueId, $target, Vigilance::currentUser());
+        } catch (\InvalidArgumentException $e) {
+            session()->flash('vigilance.flash', ['type' => 'error', 'message' => $e->getMessage()]);
+
+            return;
+        }
+
+        $this->mergeInto = '';
+        $this->redirectRoute('vigilance.issues.show', ['group' => $result['merged_into']]);
     }
 
     protected function flash(string $message): void

--- a/src/Mcp/Tools/AssignIssueTool.php
+++ b/src/Mcp/Tools/AssignIssueTool.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\AuditLogger;
+use Vigilance\Models\FailureGroup;
+
+#[Description('Assign an error issue to a specific owner (e.g. an email/handle) so it shows up in their queue — or pass an empty assignee to unassign. Unlike "acknowledge-issue" (which assigns to the MCP actor), this routes to an arbitrary owner. Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited.')]
+#[IsDestructive]
+class AssignIssueTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'id' => $schema->integer()
+                ->description('The issue id to (re)assign.')
+                ->required(),
+            'assignee' => $schema->string()
+                ->description('Owner identifier to assign to (email/handle). Empty string unassigns.'),
+        ];
+    }
+
+    public function handle(Request $request, AuditLogger $audit): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        $id = $request->integer('id');
+        $issue = FailureGroup::query()->find($id);
+
+        if ($issue === null) {
+            return Response::error("Issue [{$id}] not found.");
+        }
+
+        $assignee = trim((string) $request->get('assignee')) ?: null;
+
+        FailureGroup::query()->whereKey($id)->update(['assignee' => $assignee]);
+
+        $audit->log(
+            action: 'assign_issue',
+            subject: (string) $id,
+            meta: ['name' => $issue->name, 'assignee' => $assignee, 'source' => 'mcp'],
+            user: $this->actor($request),
+        );
+
+        return $this->json([
+            'ok' => true,
+            'id' => $id,
+            'assignee' => $assignee,
+            'status' => $assignee !== null ? 'assigned' : 'unassigned',
+        ]);
+    }
+}

--- a/src/Mcp/Tools/CustomMetricsTool.php
+++ b/src/Mcp/Tools/CustomMetricsTool.php
@@ -10,7 +10,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Vigilance\Metrics\CustomMetrics;
 use Vigilance\Metrics\CustomMetricStat;
 
-#[Description('Custom business metrics recorded via Vigilance::increment() / gauge(): counters (sum + event count) and gauges (average + peak) over a window.')]
+#[Description('Custom business metrics recorded via Vigilance::increment() / gauge() / histogram() / timing(): counters (sum + event count), gauges (average + peak) and distributions (average, max and p50/p95/p99) over a window.')]
 #[IsReadOnly]
 class CustomMetricsTool extends Tool
 {
@@ -30,12 +30,15 @@ class CustomMetricsTool extends Tool
         $window = (string) ($request->get('window') ?: '24h');
 
         $rows = $metrics->all($this->interval($window))
-            ->map(fn (CustomMetricStat $m): array => [
+            ->map(fn (CustomMetricStat $m): array => array_filter([
                 'name' => $m->name,
                 'type' => $m->type,
                 'value' => $m->value,
                 'peak' => $m->peak,
-            ])->all();
+                'p50' => $m->p50,
+                'p95' => $m->p95,
+                'p99' => $m->p99,
+            ], fn ($v) => $v !== null))->all();
 
         return $this->json([
             'window' => $window,

--- a/src/Mcp/Tools/FeedbackTool.php
+++ b/src/Mcp/Tools/FeedbackTool.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Vigilance\Models\UserFeedback;
+
+#[Description('Recent user-reported feedback captured from the widget: message, optional name/email, the page URL and the trace id the user was on (pivot to "trace" for the telemetry behind a complaint). Most recent first.')]
+#[IsReadOnly]
+class FeedbackTool extends Tool
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'limit' => $schema->integer()
+                ->description('Max feedback entries to return (capped by the server).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $limit = $this->resolveLimit($request->integer('limit') ?: null);
+
+        $rows = UserFeedback::query()
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get(['id', 'message', 'name', 'email', 'url', 'trace_id', 'user', 'created_at']);
+
+        return $this->json([
+            'count' => $rows->count(),
+            'feedback' => $rows->map(fn (UserFeedback $f): array => [
+                'id' => $f->id,
+                'message' => $this->truncate($f->message),
+                'name' => $f->name,
+                'email' => $f->email,
+                'url' => $f->url,
+                'trace_id' => $f->trace_id,
+                'user' => $f->user,
+                'at' => $this->date($f->created_at),
+            ])->all(),
+        ]);
+    }
+}

--- a/src/Mcp/Tools/MaintenanceTool.php
+++ b/src/Mcp/Tools/MaintenanceTool.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Carbon;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\AuditLogger;
+use Vigilance\Notifications\MaintenanceWindow;
+
+#[Description('Suppress alert notifications during planned maintenance (e.g. before a deploy). Actions: "start" (open an ad-hoc window for "minutes"), "stop" (close it), "status" (is alerting suppressed?). While active, no rule pages; the next cycle after it closes re-evaluates and notifies anything still breaching. Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited.')]
+#[IsDestructive]
+class MaintenanceTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'action' => $schema->string()
+                ->description('start | stop | status')
+                ->enum(['start', 'stop', 'status'])
+                ->required(),
+            'minutes' => $schema->integer()
+                ->description('For "start": window length in minutes (default 30).'),
+        ];
+    }
+
+    public function handle(Request $request, MaintenanceWindow $maintenance, AuditLogger $audit): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        $action = (string) $request->get('action');
+
+        if ($action === 'status') {
+            $until = $maintenance->adHocUntil();
+
+            return $this->json([
+                'ok' => true,
+                'suppressed' => $maintenance->active(),
+                'ad_hoc_until' => $until !== null ? $this->date(Carbon::createFromTimestamp($until)) : null,
+            ]);
+        }
+
+        if ($action === 'stop') {
+            $maintenance->stop();
+            $audit->log(action: 'maintenance_stop', meta: ['source' => 'mcp'], user: $this->actor($request));
+
+            return $this->json(['ok' => true, 'action' => 'stop', 'suppressed' => false]);
+        }
+
+        $minutes = max(1, $request->integer('minutes') ?: 30);
+        $until = $maintenance->start($minutes);
+
+        $audit->log(action: 'maintenance_start', meta: ['minutes' => $minutes, 'source' => 'mcp'], user: $this->actor($request));
+
+        return $this->json([
+            'ok' => true,
+            'action' => 'start',
+            'minutes' => $minutes,
+            'suppressed' => true,
+            'until' => $this->date(Carbon::createFromTimestamp($until)),
+        ]);
+    }
+}

--- a/src/Mcp/Tools/MergeIssuesTool.php
+++ b/src/Mcp/Tools/MergeIssuesTool.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\IssueMerger;
+
+#[Description('Merge one error issue into another when fingerprinting split the same problem into two. The source issue\'s occurrences and runs move to the target, the source is hidden, and future occurrences of its signature are redirected to the target. Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited.')]
+#[IsDestructive]
+class MergeIssuesTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'from' => $schema->integer()
+                ->description('The source issue id to merge (it will be hidden).')
+                ->required(),
+            'into' => $schema->integer()
+                ->description('The target/canonical issue id to merge into.')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request, IssueMerger $merger): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        try {
+            $result = $merger->merge($request->integer('from'), $request->integer('into'), $this->actor($request));
+        } catch (\InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return $this->json(array_merge(['ok' => true], $result));
+    }
+}

--- a/src/Mcp/Tools/RecordDeployTool.php
+++ b/src/Mcp/Tools/RecordDeployTool.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Carbon;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Vigilance\Control\AuditLogger;
+use Vigilance\Models\Deployment;
+
+#[Description('Record a deployment marker so metric/error changes can be correlated with releases (the same marker vigilance:deploy writes, and what release-health / deploy-regression alerts compare against). Requires MCP writes (VIGILANCE_MCP_ALLOW_WRITES=true). Audited.')]
+#[IsDestructive]
+class RecordDeployTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return $this->writesEnabled();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'release' => $schema->string()
+                ->description('The release version/tag (e.g. "v1.4.0").'),
+            'commit' => $schema->string()
+                ->description('The deployed commit SHA.'),
+            'notes' => $schema->string()
+                ->description('Free-form notes about the deploy.'),
+        ];
+    }
+
+    public function handle(Request $request, AuditLogger $audit): Response
+    {
+        if (! $this->writesEnabled()) {
+            return Response::error('Vigilance MCP writes are disabled. Set vigilance.mcp.allow_writes to enable them.');
+        }
+
+        $release = trim((string) $request->get('release')) ?: null;
+        $commit = trim((string) $request->get('commit')) ?: null;
+        $notes = trim((string) $request->get('notes')) ?: null;
+
+        if ($release === null && $commit === null) {
+            return Response::error('Provide at least a "release" or a "commit".');
+        }
+
+        $now = Carbon::now();
+        $deployment = Deployment::query()->create([
+            'version' => $release,
+            'commit' => $commit,
+            'environment' => app()->environment(),
+            'notes' => $notes,
+            'deployed_at' => $now,
+            'created_at' => $now,
+        ]);
+
+        $audit->log(
+            action: 'record_deploy',
+            subject: $deployment->label(),
+            meta: ['release' => $release, 'commit' => $commit, 'environment' => app()->environment(), 'source' => 'mcp'],
+            user: $this->actor($request),
+        );
+
+        return $this->json([
+            'ok' => true,
+            'id' => $deployment->id,
+            'label' => $deployment->label(),
+            'environment' => app()->environment(),
+        ]);
+    }
+}

--- a/src/Mcp/Tools/RoutesTool.php
+++ b/src/Mcp/Tools/RoutesTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Vigilance\Metrics\RoutePerformance;
+use Vigilance\Metrics\RouteStat;
+
+#[Description('Per-route HTTP performance over a window: request count, error count/rate, Apdex, average/max latency and p50/p95/p99 — the ranked route table from the dashboard (complements "slow-requests"/"slow-http" which surface individual slow calls). Window like 15m, 1h, 24h, 7d.')]
+#[IsReadOnly]
+class RoutesTool extends Tool
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'window' => $schema->string()
+                ->description('Time window: 15m, 1h, 24h, 7d, 2w. Defaults to 1h.'),
+            'limit' => $schema->integer()
+                ->description('Max routes to return (ranked by request count).'),
+        ];
+    }
+
+    public function handle(Request $request, RoutePerformance $routes): Response
+    {
+        $window = (string) ($request->get('window') ?: '1h');
+        $limit = $this->resolveLimit($request->integer('limit') ?: null);
+
+        $rows = $routes->forInterval($this->interval($window), $limit);
+
+        return $this->json([
+            'window' => $window,
+            'count' => $rows->count(),
+            'routes' => $rows->map(fn (RouteStat $r): array => [
+                'method' => $r->method,
+                'path' => $r->path,
+                'requests' => $r->count,
+                'errors' => $r->errors,
+                'error_rate' => $r->error_rate,
+                'apdex' => $r->apdex,
+                'avg_ms' => $r->avg,
+                'max_ms' => $r->max,
+                'p50_ms' => $r->p50,
+                'p95_ms' => $r->p95,
+                'p99_ms' => $r->p99,
+            ])->all(),
+        ]);
+    }
+}

--- a/src/Mcp/Tools/WorkloadTool.php
+++ b/src/Mcp/Tools/WorkloadTool.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Vigilance\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Vigilance\Metrics\Stats;
+use Vigilance\Metrics\Workload;
+
+#[Description('Worker workload overview: system load average (1/5/15m) and a per-job-class breakdown over a window (runs, failures, fail %, avg/max runtime, avg memory/CPU). Pairs with "queues" (per-queue depth/throughput) for the full Workload dashboard view.')]
+#[IsReadOnly]
+class WorkloadTool extends Tool
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'window' => $schema->string()
+                ->description('Time window for the job-class breakdown: 15m, 1h, 24h, 7d. Defaults to 24h.'),
+        ];
+    }
+
+    public function handle(Request $request, Workload $workload, Stats $stats): Response
+    {
+        $window = (string) ($request->get('window') ?: '24h');
+        $limit = $this->resolveLimit();
+
+        return $this->json([
+            'system_load' => $workload->load(),
+            'window' => $window,
+            'job_classes' => array_slice($stats->byJobClass($window, $limit), 0, $limit),
+        ]);
+    }
+}

--- a/src/Mcp/VigilanceServer.php
+++ b/src/Mcp/VigilanceServer.php
@@ -17,6 +17,7 @@ use Vigilance\Mcp\Tools\CustomMetricsTool;
 use Vigilance\Mcp\Tools\DispatchableJobsTool;
 use Vigilance\Mcp\Tools\DispatchJobTool;
 use Vigilance\Mcp\Tools\ExceptionsTool;
+use Vigilance\Mcp\Tools\FeedbackTool;
 use Vigilance\Mcp\Tools\IncidentsTool;
 use Vigilance\Mcp\Tools\IssuesTool;
 use Vigilance\Mcp\Tools\IssueTool;
@@ -125,6 +126,7 @@ class VigilanceServer extends Server
         TraceTool::class,
         LogsTool::class,
         VitalsTool::class,
+        FeedbackTool::class,
         SlosTool::class,
         IncidentsTool::class,
         ReleasesTool::class,

--- a/src/Mcp/VigilanceServer.php
+++ b/src/Mcp/VigilanceServer.php
@@ -22,6 +22,7 @@ use Vigilance\Mcp\Tools\IssuesTool;
 use Vigilance\Mcp\Tools\IssueTool;
 use Vigilance\Mcp\Tools\JobMetricsTool;
 use Vigilance\Mcp\Tools\LogsTool;
+use Vigilance\Mcp\Tools\MaintenanceTool;
 use Vigilance\Mcp\Tools\MuteIssueTool;
 use Vigilance\Mcp\Tools\OverviewTool;
 use Vigilance\Mcp\Tools\PauseQueueTool;
@@ -146,6 +147,7 @@ class VigilanceServer extends Server
         RetryRunTool::class,
         RetryIssueTool::class,
         RecordDeployTool::class,
+        MaintenanceTool::class,
         // Worker & queue control (self-gate on mcp.allow_writes). Pausing/resuming
         // a queue or the fleet is operational; clearing a queue and cancelling
         // pending jobs are destructive and additionally require control.enabled.

--- a/src/Mcp/VigilanceServer.php
+++ b/src/Mcp/VigilanceServer.php
@@ -7,6 +7,7 @@ use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Tool;
 use Vigilance\Mcp\Tools\AcknowledgeIssueTool;
+use Vigilance\Mcp\Tools\AssignIssueTool;
 use Vigilance\Mcp\Tools\BatchesTool;
 use Vigilance\Mcp\Tools\CacheTool;
 use Vigilance\Mcp\Tools\CancelPendingTool;
@@ -27,12 +28,14 @@ use Vigilance\Mcp\Tools\PauseQueueTool;
 use Vigilance\Mcp\Tools\PendingTool;
 use Vigilance\Mcp\Tools\PerformanceTool;
 use Vigilance\Mcp\Tools\QueuesTool;
+use Vigilance\Mcp\Tools\RecordDeployTool;
 use Vigilance\Mcp\Tools\ReleasesTool;
 use Vigilance\Mcp\Tools\ReopenIssueTool;
 use Vigilance\Mcp\Tools\ResolveIssueTool;
 use Vigilance\Mcp\Tools\ResumeQueueTool;
 use Vigilance\Mcp\Tools\RetryIssueTool;
 use Vigilance\Mcp\Tools\RetryRunTool;
+use Vigilance\Mcp\Tools\RoutesTool;
 use Vigilance\Mcp\Tools\RunCommandTool;
 use Vigilance\Mcp\Tools\RunnableCommandsTool;
 use Vigilance\Mcp\Tools\RunsTool;
@@ -50,6 +53,7 @@ use Vigilance\Mcp\Tools\TraceTool;
 use Vigilance\Mcp\Tools\UsageTool;
 use Vigilance\Mcp\Tools\VitalsTool;
 use Vigilance\Mcp\Tools\WorkersTool;
+use Vigilance\Mcp\Tools\WorkloadTool;
 use Vigilance\Vigilance;
 
 /**
@@ -126,6 +130,8 @@ class VigilanceServer extends Server
         // Operational (workers, queues, scheduler, batches, tags).
         WorkersTool::class,
         QueuesTool::class,
+        WorkloadTool::class,
+        RoutesTool::class,
         PendingTool::class,
         JobMetricsTool::class,
         ScheduleTool::class,
@@ -136,8 +142,10 @@ class VigilanceServer extends Server
         AcknowledgeIssueTool::class,
         MuteIssueTool::class,
         ReopenIssueTool::class,
+        AssignIssueTool::class,
         RetryRunTool::class,
         RetryIssueTool::class,
+        RecordDeployTool::class,
         // Worker & queue control (self-gate on mcp.allow_writes). Pausing/resuming
         // a queue or the fleet is operational; clearing a queue and cancelling
         // pending jobs are destructive and additionally require control.enabled.

--- a/src/Mcp/VigilanceServer.php
+++ b/src/Mcp/VigilanceServer.php
@@ -23,6 +23,7 @@ use Vigilance\Mcp\Tools\IssueTool;
 use Vigilance\Mcp\Tools\JobMetricsTool;
 use Vigilance\Mcp\Tools\LogsTool;
 use Vigilance\Mcp\Tools\MaintenanceTool;
+use Vigilance\Mcp\Tools\MergeIssuesTool;
 use Vigilance\Mcp\Tools\MuteIssueTool;
 use Vigilance\Mcp\Tools\OverviewTool;
 use Vigilance\Mcp\Tools\PauseQueueTool;
@@ -144,6 +145,7 @@ class VigilanceServer extends Server
         MuteIssueTool::class,
         ReopenIssueTool::class,
         AssignIssueTool::class,
+        MergeIssuesTool::class,
         RetryRunTool::class,
         RetryIssueTool::class,
         RecordDeployTool::class,

--- a/src/Metrics/CustomMetricStat.php
+++ b/src/Metrics/CustomMetricStat.php
@@ -5,7 +5,9 @@ namespace Vigilance\Metrics;
 /**
  * One custom metric over a window. For counters, "value" is the total (sum) and
  * "peak" the number of events; for gauges, "value" is the average and "peak"
- * the maximum. "series" is a null-padded sparkline.
+ * the maximum; for distributions, "value" is the average, "peak" the max, and
+ * p50/p95/p99 the percentiles over the retained samples. "series" is a
+ * null-padded sparkline.
  */
 class CustomMetricStat
 {
@@ -18,5 +20,8 @@ class CustomMetricStat
         public int $value,
         public int $peak,
         public array $series,
+        public ?int $p50 = null,
+        public ?int $p95 = null,
+        public ?int $p99 = null,
     ) {}
 }

--- a/src/Metrics/CustomMetrics.php
+++ b/src/Metrics/CustomMetrics.php
@@ -2,8 +2,10 @@
 
 namespace Vigilance\Metrics;
 
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Vigilance\Apm\Contracts\Storage;
 
 /**
@@ -48,7 +50,87 @@ class CustomMetrics
             ));
         }
 
+        $distributions = $this->storage->aggregate('metric_distribution', ['avg', 'max', 'count'], $interval, orderBy: 'count', limit: 100);
+        $distGraph = $this->storage->graph(['metric_distribution'], 'avg', $interval);
+        $percentiles = $this->percentiles($interval, $distributions->map(fn ($r) => (string) $r->key)->all());
+
+        foreach ($distributions as $row) {
+            $p = $percentiles[(string) $row->key] ?? ['p50' => null, 'p95' => null, 'p99' => null];
+
+            $out->push(new CustomMetricStat(
+                name: (string) $row->key,
+                type: 'distribution',
+                value: (int) round((float) $row->avg),
+                peak: (int) $row->max,
+                series: $this->series($distGraph, (string) $row->key, 'metric_distribution'),
+                p50: $p['p50'],
+                p95: $p['p95'],
+                p99: $p['p99'],
+            ));
+        }
+
         return $out->sortBy('name')->values();
+    }
+
+    /**
+     * Exact p50/p95/p99 per distribution key, from the retained raw samples
+     * within the window (mirrors RoutePerformance's request-latency percentiles).
+     *
+     * @param  list<string>  $keys
+     * @return array<string, array{p50:?int, p95:?int, p99:?int}>
+     */
+    protected function percentiles(CarbonInterval $interval, array $keys): array
+    {
+        if ($keys === []) {
+            return [];
+        }
+
+        $windowStart = CarbonImmutable::now()->getTimestamp() - (int) $interval->totalSeconds + 1;
+
+        $rows = DB::connection(config('vigilance.storage.connection') ?: config('database.default'))
+            ->table('vigilance_entries')
+            ->select('key', 'value')
+            ->where('type', 'metric_distribution')
+            ->whereIn('key', $keys)
+            ->where('timestamp', '>=', $windowStart)
+            ->whereNotNull('value')
+            ->get();
+
+        /** @var array<string, list<int>> $byKey */
+        $byKey = [];
+        foreach ($rows as $row) {
+            $byKey[(string) $row->key][] = (int) $row->value;
+        }
+
+        $out = [];
+        foreach ($byKey as $key => $values) {
+            sort($values);
+            $out[$key] = [
+                'p50' => $this->quantile($values, 0.50),
+                'p95' => $this->quantile($values, 0.95),
+                'p99' => $this->quantile($values, 0.99),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Nearest-rank quantile over a pre-sorted list.
+     *
+     * @param  list<int>  $sorted
+     */
+    protected function quantile(array $sorted, float $q): ?int
+    {
+        $n = count($sorted);
+
+        if ($n === 0) {
+            return null;
+        }
+
+        $rank = (int) ceil($q * $n) - 1;
+
+        return $sorted[max(0, min($n - 1, $rank))];
     }
 
     /**

--- a/src/Models/FailureGroup.php
+++ b/src/Models/FailureGroup.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Carbon;
  * @property ?Carbon $first_seen_at
  * @property ?Carbon $last_seen_at
  * @property ?Carbon $resolved_at
+ * @property ?int $merged_into
  * @property ?Carbon $regressed_at
  * @property ?Carbon $muted_until
  * @property ?string $sample
@@ -35,6 +36,7 @@ class FailureGroup extends VigilanceModel
 
     protected $casts = [
         'occurrences' => 'integer',
+        'merged_into' => 'integer',
         'acknowledged_at' => 'datetime',
         'first_seen_at' => 'datetime',
         'last_seen_at' => 'datetime',

--- a/src/Models/UserFeedback.php
+++ b/src/Models/UserFeedback.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Vigilance\Models;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * A piece of user-reported feedback ("this page is slow", "the export is
+ * broken") captured from the embedded widget — tied to the trace the user was
+ * on so you can jump from the complaint to the technical telemetry.
+ *
+ * @property int $id
+ * @property string $message
+ * @property ?string $email
+ * @property ?string $name
+ * @property ?string $url
+ * @property ?string $trace_id
+ * @property ?string $user
+ * @property ?Carbon $created_at
+ */
+class UserFeedback extends VigilanceModel
+{
+    protected $table = 'vigilance_user_feedback';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+}

--- a/src/Notifications/AlertManager.php
+++ b/src/Notifications/AlertManager.php
@@ -57,6 +57,13 @@ class AlertManager
             return 0;
         }
 
+        // Planned maintenance: suppress notifications entirely. Rules aren't
+        // evaluated/dispatched, so nothing pages; the next cycle after the window
+        // closes re-evaluates and notifies for anything still breaching.
+        if (app(MaintenanceWindow::class)->active()) {
+            return 0;
+        }
+
         $throttle = (int) config('vigilance.alerts.throttle_minutes', 15);
         $renotify = (int) config('vigilance.alerts.renotify_minutes', 0);
         $sent = 0;

--- a/src/Notifications/AlertManager.php
+++ b/src/Notifications/AlertManager.php
@@ -14,6 +14,7 @@ use Vigilance\Notifications\Rules\AnomalyRule;
 use Vigilance\Notifications\Rules\ErrorRateRule;
 use Vigilance\Notifications\Rules\ExceptionSpikeRule;
 use Vigilance\Notifications\Rules\IssueRegressionRule;
+use Vigilance\Notifications\Rules\LongRunningJobRule;
 use Vigilance\Notifications\Rules\NewIssueRule;
 use Vigilance\Notifications\Rules\QueueLongWaitRule;
 use Vigilance\Notifications\Rules\ReleaseHealthRule;
@@ -34,6 +35,7 @@ class AlertManager
     /** @var list<class-string<AlertRule>> */
     protected array $builtInRules = [
         QueueLongWaitRule::class,
+        LongRunningJobRule::class,
         ErrorRateRule::class,
         ExceptionSpikeRule::class,
         SlowRequestRateRule::class,

--- a/src/Notifications/AlertManager.php
+++ b/src/Notifications/AlertManager.php
@@ -16,6 +16,7 @@ use Vigilance\Notifications\Rules\ExceptionSpikeRule;
 use Vigilance\Notifications\Rules\IssueRegressionRule;
 use Vigilance\Notifications\Rules\LongRunningJobRule;
 use Vigilance\Notifications\Rules\NewIssueRule;
+use Vigilance\Notifications\Rules\NPlusOneRule;
 use Vigilance\Notifications\Rules\QueueLongWaitRule;
 use Vigilance\Notifications\Rules\ReleaseHealthRule;
 use Vigilance\Notifications\Rules\ScheduledTaskLateRule;
@@ -36,6 +37,7 @@ class AlertManager
     protected array $builtInRules = [
         QueueLongWaitRule::class,
         LongRunningJobRule::class,
+        NPlusOneRule::class,
         ErrorRateRule::class,
         ExceptionSpikeRule::class,
         SlowRequestRateRule::class,

--- a/src/Notifications/MaintenanceWindow.php
+++ b/src/Notifications/MaintenanceWindow.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Vigilance\Notifications;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Alert suppression during planned maintenance. While a window is active,
+ * AlertManager stops notifying — rules aren't dispatched, so a deploy or a known
+ * noisy migration doesn't page anyone. When the window ends, the next snapshot
+ * cycle re-evaluates and notifies for anything still breaching, so nothing is
+ * permanently lost.
+ *
+ * Two sources, either of which suppresses:
+ *  - an ad-hoc window an operator/agent opens (cache flag with an expiry), and
+ *  - recurring windows declared in config (e.g. nightly batch hours).
+ */
+class MaintenanceWindow
+{
+    protected const KEY = 'vigilance:maintenance:until';
+
+    protected function cache(): Repository
+    {
+        return Cache::store(config('vigilance.notifications.cache_store'));
+    }
+
+    /**
+     * Open an ad-hoc maintenance window for the given number of minutes.
+     */
+    public function start(int $minutes): int
+    {
+        $minutes = max(1, $minutes);
+        $until = Carbon::now()->getTimestamp() + $minutes * 60;
+
+        // TTL a touch beyond the window so the flag self-clears if never stopped.
+        $this->cache()->put(self::KEY, $until, $minutes * 60 + 60);
+
+        return $until;
+    }
+
+    public function stop(): void
+    {
+        $this->cache()->forget(self::KEY);
+    }
+
+    /**
+     * The ad-hoc window's expiry epoch, or null when none is open.
+     */
+    public function adHocUntil(): ?int
+    {
+        $until = $this->cache()->get(self::KEY);
+
+        if ($until === null) {
+            return null;
+        }
+
+        if ((int) $until <= Carbon::now()->getTimestamp()) {
+            $this->cache()->forget(self::KEY);
+
+            return null;
+        }
+
+        return (int) $until;
+    }
+
+    /**
+     * Whether alert notifications are currently suppressed.
+     */
+    public function active(): bool
+    {
+        return $this->adHocUntil() !== null || $this->inRecurringWindow(Carbon::now());
+    }
+
+    /**
+     * Match "now" against the recurring windows in config:
+     * notifications.maintenance = [ ['days' => ['sat','sun'], 'from' => '02:00', 'to' => '04:00'], … ]
+     * "days" is optional (defaults to every day); a window whose "to" is <= "from"
+     * wraps past midnight.
+     */
+    protected function inRecurringWindow(Carbon $now): bool
+    {
+        $windows = config('vigilance.notifications.maintenance', []);
+
+        if (! is_array($windows)) {
+            return false;
+        }
+
+        $day = strtolower($now->format('D')); // mon, tue, …
+        $minutes = $now->hour * 60 + $now->minute;
+
+        foreach ($windows as $window) {
+            if (! is_array($window)) {
+                continue;
+            }
+
+            $days = array_map('strtolower', (array) ($window['days'] ?? []));
+            if ($days !== [] && ! in_array($day, $days, true) && ! in_array(substr($day, 0, 3), $days, true)) {
+                continue;
+            }
+
+            $from = $this->toMinutes($window['from'] ?? null);
+            $to = $this->toMinutes($window['to'] ?? null);
+
+            if ($from === null || $to === null) {
+                continue;
+            }
+
+            $match = $to > $from
+                ? ($minutes >= $from && $minutes < $to)
+                : ($minutes >= $from || $minutes < $to); // wraps midnight
+
+            if ($match) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function toMinutes(mixed $time): ?int
+    {
+        if (! is_string($time) || ! preg_match('/^(\d{1,2}):(\d{2})$/', trim($time), $m)) {
+            return null;
+        }
+
+        return ((int) $m[1]) * 60 + (int) $m[2];
+    }
+}

--- a/src/Notifications/Rules/LongRunningJobRule.php
+++ b/src/Notifications/Rules/LongRunningJobRule.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Vigilance\Notifications\Rules;
+
+use Illuminate\Support\Carbon;
+use Vigilance\Enums\RunStatus;
+use Vigilance\Enums\RunType;
+use Vigilance\Models\Run;
+use Vigilance\Notifications\Alert;
+use Vigilance\Notifications\Contracts\AlertRule;
+
+/**
+ * Fires for jobs that have been running far longer than expected — a runaway or
+ * stuck worker that queue_long_wait (which watches backlog) and the failure
+ * rules (which watch completed failures) both miss, because the job never
+ * finishes to report anything.
+ */
+class LongRunningJobRule implements AlertRule
+{
+    public function evaluate(): iterable
+    {
+        if (! config('vigilance.alerts.rules.long_running_job.enabled', false)) {
+            return;
+        }
+
+        $threshold = max(1, (int) config('vigilance.alerts.rules.long_running_job.seconds', 300));
+        $limit = max(1, (int) config('vigilance.alerts.rules.long_running_job.limit', 10));
+        $cutoff = Carbon::now()->subSeconds($threshold);
+
+        $runs = Run::query()
+            ->where('type', RunType::Job->value)
+            ->where('status', RunStatus::Running->value)
+            ->whereNotNull('started_at')
+            ->where('started_at', '<', $cutoff)
+            ->orderBy('started_at')
+            ->limit($limit)
+            ->get(['id', 'name', 'queue', 'connection_name', 'started_at']);
+
+        foreach ($runs as $run) {
+            $seconds = (int) round($run->started_at->diffInSeconds(Carbon::now()));
+            $where = trim(($run->connection_name ? $run->connection_name.':' : '').($run->queue ?? ''), ':');
+
+            yield new Alert(
+                key: 'long_running_job:'.$run->id,
+                title: 'Long-running job',
+                message: "Job [{$run->name}] has been running for {$seconds}s"
+                    .($where !== '' ? " on [{$where}]" : '')
+                    .' — it may be stuck or runaway.',
+                level: 'warning',
+            );
+        }
+    }
+}

--- a/src/Notifications/Rules/NPlusOneRule.php
+++ b/src/Notifications/Rules/NPlusOneRule.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Vigilance\Notifications\Rules;
+
+use Carbon\CarbonInterval;
+use Vigilance\Apm\Contracts\Storage;
+use Vigilance\Notifications\Alert;
+use Vigilance\Notifications\Contracts\AlertRule;
+
+/**
+ * Fires when N+1 query patterns (detected by the tracer and promoted to the
+ * "n_plus_one" APM signal) recur for a route/job over the window — a first-class
+ * alert for a problem you'd otherwise have to catch one trace at a time.
+ */
+class NPlusOneRule implements AlertRule
+{
+    public function __construct(protected Storage $storage) {}
+
+    public function evaluate(): iterable
+    {
+        if (! config('vigilance.alerts.rules.n_plus_one.enabled', false)) {
+            return;
+        }
+
+        $minOccurrences = max(1, (int) config('vigilance.alerts.rules.n_plus_one.min_occurrences', 5));
+        $window = (string) config('vigilance.alerts.rules.n_plus_one.window', '1h');
+
+        $rows = $this->storage->aggregate('n_plus_one', ['count', 'max'], $this->interval($window), orderBy: 'count', limit: 20);
+
+        foreach ($rows as $row) {
+            $occurrences = (int) $row->count;
+
+            if ($occurrences < $minOccurrences) {
+                continue;
+            }
+
+            $name = (string) $row->key;
+            $worst = (int) $row->max;
+
+            yield new Alert(
+                key: 'n_plus_one:'.$name,
+                title: 'N+1 query pattern',
+                message: "N+1 queries detected on [{$name}] — seen {$occurrences} time(s) in the last {$window}, "
+                    ."worst trace repeated a query {$worst} times.",
+                level: 'warning',
+            );
+        }
+    }
+
+    protected function interval(string $window): CarbonInterval
+    {
+        if (! preg_match('/^(\d+)\s*(m|h|d)$/i', trim($window), $m)) {
+            return CarbonInterval::hour();
+        }
+
+        $value = max(1, (int) $m[1]);
+
+        return match (strtolower($m[2])) {
+            'm' => CarbonInterval::minutes($value),
+            'd' => CarbonInterval::days($value),
+            default => CarbonInterval::hours($value),
+        };
+    }
+}

--- a/src/Support/Breadcrumbs.php
+++ b/src/Support/Breadcrumbs.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Vigilance\Support;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * A bounded, per-unit-of-work trail of events leading up to a failure — the
+ * "what happened just before the error" that turns a bare stack trace into a
+ * story. Application code adds crumbs via Vigilance::breadcrumb(), and log lines
+ * are recorded automatically. On an exception the trail is attached to the
+ * issue's context (latest-wins, Sentry-style).
+ *
+ * Held in a ring buffer (oldest dropped past the cap) and cleared at each
+ * request/job boundary so trails never leak across units of work.
+ */
+class Breadcrumbs
+{
+    /** @var list<array{t:string, level:string, category:?string, message:string, data:array<string,mixed>}> */
+    protected array $crumbs = [];
+
+    public function __construct(protected int $max = 25) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function add(string $message, ?string $category = null, string $level = 'info', array $data = []): void
+    {
+        $this->crumbs[] = [
+            't' => Carbon::now()->toIso8601String(),
+            'level' => $level,
+            'category' => $category,
+            'message' => Str::limit($message, 500),
+            'data' => $data === [] ? [] : Redactor::redact($data),
+        ];
+
+        $overflow = count($this->crumbs) - max(1, $this->max);
+        if ($overflow > 0) {
+            $this->crumbs = array_slice($this->crumbs, $overflow);
+        }
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function all(): array
+    {
+        return $this->crumbs;
+    }
+
+    public function clear(): void
+    {
+        $this->crumbs = [];
+    }
+
+    /**
+     * The context fragment to merge into a stored issue — empty when there is no
+     * trail, so nothing is written for errors that had no preceding activity.
+     *
+     * @return array<string, mixed>
+     */
+    public function contextFragment(): array
+    {
+        return $this->crumbs === [] ? [] : ['breadcrumbs' => $this->crumbs];
+    }
+}

--- a/src/Tracing/Middleware/TraceRequests.php
+++ b/src/Tracing/Middleware/TraceRequests.php
@@ -23,6 +23,9 @@ class TraceRequests
         if ($this->shouldTrace($request)) {
             $start = defined('LARAVEL_START') ? LARAVEL_START : microtime(true);
 
+            // Continue an upstream distributed trace when the caller sent one.
+            $this->tracer->continueFrom($request->header('traceparent'));
+
             $this->tracer->start('request', $request->method().' '.$this->path($request), $start, [
                 'method' => $request->method(),
                 'path' => $this->path($request),

--- a/src/Tracing/Tracer.php
+++ b/src/Tracing/Tracer.php
@@ -31,6 +31,14 @@ class Tracer
      */
     protected ?array $current = null;
 
+    /**
+     * Upstream context (W3C traceparent) to fold into the next trace, set by
+     * continueFrom() and consumed by start(). Null when this unit is a root.
+     *
+     * @var array{trace_id:string, span_id:string}|null
+     */
+    protected ?array $pendingParent = null;
+
     protected bool $enabled;
 
     protected int $maxSpans;
@@ -80,10 +88,20 @@ class Tracer
     public function start(string $type, string $name, ?float $start = null, array $attributes = []): void
     {
         if (! $this->enabled || $this->current !== null) {
+            $this->pendingParent = null;
+
             return;
         }
 
         $this->rescue(function () use ($type, $name, $start, $attributes) {
+            // Distributed tracing: if an upstream context was handed in (an HTTP
+            // traceparent header, or a dispatching request's context carried on
+            // the job payload), record it so this trace links to its parent.
+            if ($this->pendingParent !== null) {
+                $attributes['parent_trace_id'] = $this->pendingParent['trace_id'];
+                $attributes['parent_span_id'] = $this->pendingParent['span_id'];
+            }
+
             $this->current = [
                 'id' => (string) Str::orderedUuid(),
                 'type' => $type,
@@ -94,7 +112,54 @@ class Tracer
                 'spans' => [],
                 'dropped' => 0,
             ];
+
+            $this->pendingParent = null;
         });
+    }
+
+    /**
+     * Continue an upstream trace from a W3C traceparent
+     * (00-{trace-id:32hex}-{span-id:16hex}-{flags:2hex}). The parent is folded
+     * into the next start()ed trace's attributes. A null/invalid/all-zero value
+     * is ignored (this unit becomes its own root). Returns whether it was taken.
+     */
+    public function continueFrom(?string $traceparent): bool
+    {
+        $this->pendingParent = null;
+
+        if (! is_string($traceparent) || ! config('vigilance.tracing.propagation', true)) {
+            return false;
+        }
+
+        if (! preg_match('/^[0-9a-f]{2}-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/i', trim($traceparent), $m)) {
+            return false;
+        }
+
+        if (trim($m[1], '0') === '' || trim($m[2], '0') === '') {
+            return false; // all-zero ids are invalid per the spec
+        }
+
+        $this->pendingParent = ['trace_id' => strtolower($m[1]), 'span_id' => strtolower($m[2])];
+
+        return true;
+    }
+
+    /**
+     * A W3C traceparent for the in-flight trace, to propagate downstream (into an
+     * outgoing HTTP call or a dispatched job). Null when no trace is active. The
+     * span-id is fresh per call so each downstream hop has a distinct parent span.
+     */
+    public function traceparent(): ?string
+    {
+        if ($this->current === null) {
+            return null;
+        }
+
+        $traceId = substr(str_replace('-', '', (string) $this->current['id']).str_repeat('0', 32), 0, 32);
+        $spanId = substr(bin2hex(random_bytes(8)), 0, 16);
+        $flags = ! empty($this->current['sampled']) ? '01' : '00';
+
+        return "00-{$traceId}-{$spanId}-{$flags}";
     }
 
     /**
@@ -213,6 +278,7 @@ class Tracer
     public function flush(): void
     {
         $this->current = null;
+        $this->pendingParent = null;
     }
 
     public function setContainer(Container $container): void

--- a/src/Tracing/Tracer.php
+++ b/src/Tracing/Tracer.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Lottery;
 use Illuminate\Support\Str;
 use Throwable;
+use Vigilance\Apm\Apm;
 use Vigilance\Tracing\Contracts\TraceStorage;
 use Vigilance\Tracing\Sampling\Sampler;
 
@@ -250,6 +251,13 @@ class Tracer
 
             if ($nPlusOne = $this->detectNPlusOne($trace['spans'])) {
                 $attributes['n_plus_one'] = $nPlusOne;
+
+                // Promote N+1 to a first-class, aggregatable APM signal (keyed by
+                // the route/job name) so it can be counted and alerted on, not
+                // only spotted one trace at a time.
+                $this->rescue(fn () => $this->app->make(Apm::class)
+                    ->record('n_plus_one', (string) $trace['name'], (int) $nPlusOne['count'])
+                    ->count()->max());
             }
 
             $this->app->make(TraceStorage::class)->store([

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -9,6 +9,7 @@ use Vigilance\Apm\Apm;
 use Vigilance\Contracts\ShouldNotBeMonitored;
 use Vigilance\Events\ExceptionReported;
 use Vigilance\Notifications\Alert;
+use Vigilance\Support\Breadcrumbs;
 use Vigilance\Support\Defaults;
 
 /**
@@ -156,6 +157,30 @@ class Vigilance
     {
         static::$recording = true;
         static::$manualContext = null;
+
+        // Breadcrumb trails are per-unit-of-work; drop them at the boundary so a
+        // long-lived worker never attaches one request's trail to the next error.
+        try {
+            app(Breadcrumbs::class)->clear();
+        } catch (\Throwable) {
+            // Breadcrumbs are best-effort; never break the boundary reset.
+        }
+    }
+
+    /**
+     * Leave a breadcrumb — a note about something that just happened — so that if
+     * an error follows, its issue shows the trail that led up to it. Guarded: a
+     * breadcrumb can never break the host application.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function breadcrumb(string $message, ?string $category = null, string $level = 'info', array $data = []): void
+    {
+        try {
+            app(Breadcrumbs::class)->add($message, $category, $level, $data);
+        } catch (\Throwable) {
+            //
+        }
     }
 
     public static function shouldRecord(): bool

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -19,7 +19,7 @@ use Vigilance\Support\Defaults;
  */
 class Vigilance
 {
-    public static string $version = '0.7.0';
+    public static string $version = '0.8.0';
 
     /** Cache-busting token for the bundled stylesheet, derived from its contents. */
     protected static ?string $assetVersion = null;

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -32,7 +32,7 @@ class Vigilance
 
     protected static bool $recording = true;
 
-    /** @var array{user: ?string, via: string}|null */
+    /** @var array{user: ?string, via: string, retry_of?: ?int}|null */
     protected static ?array $manualContext = null;
 
     /** @var list<string>|null null = not set in code, fall back to config */
@@ -314,10 +314,10 @@ class Vigilance
      * @param  Closure(): T  $callback
      * @return T
      */
-    public static function asManual(?string $user, Closure $callback): mixed
+    public static function asManual(?string $user, Closure $callback, ?int $retryOf = null): mixed
     {
         $previous = static::$manualContext;
-        static::$manualContext = ['user' => $user, 'via' => 'manual'];
+        static::$manualContext = ['user' => $user, 'via' => 'manual', 'retry_of' => $retryOf];
 
         try {
             return $callback();
@@ -326,7 +326,7 @@ class Vigilance
         }
     }
 
-    /** @return array{user: ?string, via: string}|null */
+    /** @return array{user: ?string, via: string, retry_of?: ?int}|null */
     public static function manualContext(): ?array
     {
         return static::$manualContext;

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -252,6 +252,39 @@ class Vigilance
     }
 
     /**
+     * Decrement a custom counter (records a negative delta into the same series
+     * as increment()). Never throws.
+     */
+    public static function decrement(string $name, int $by = 1): void
+    {
+        static::increment($name, -abs($by));
+    }
+
+    /**
+     * Record a custom distribution / histogram sample (e.g. checkout latency,
+     * payload size). The Custom Metrics dashboard reports p50/p95/p99 + average
+     * over the window from the retained samples. Floats are rounded — scale
+     * first if you need sub-unit precision. Never throws.
+     */
+    public static function histogram(string $name, int|float $value): void
+    {
+        try {
+            app(Apm::class)->record('metric_distribution', $name, (int) round($value))->count()->avg()->max();
+        } catch (\Throwable) {
+            //
+        }
+    }
+
+    /**
+     * Record a timing sample in milliseconds — a distribution named for latency.
+     * Alias of histogram() with duration semantics. Never throws.
+     */
+    public static function timing(string $name, int|float $milliseconds): void
+    {
+        static::histogram($name, $milliseconds);
+    }
+
+    /**
      * Run a callback without recording (prevents the recorder from observing
      * its own writes).
      *

--- a/src/VigilanceServiceProvider.php
+++ b/src/VigilanceServiceProvider.php
@@ -444,9 +444,9 @@ class VigilanceServiceProvider extends ServiceProvider
 
         // --- Distributed propagation --------------------------------------
         // Emit a W3C traceparent on outgoing HTTP so downstream services can
-        // continue the trace. Guarded and only when a trace is in flight.
-        if (config('vigilance.tracing.propagation', true)
-            && method_exists(Http::class, 'globalRequestMiddleware')) {
+        // continue the trace (globalRequestMiddleware exists on the Http client
+        // factory in all supported Laravel versions). Only when a trace is live.
+        if (config('vigilance.tracing.propagation', true)) {
             Http::globalRequestMiddleware(function ($request) use ($tracer) {
                 try {
                     if (! $request->hasHeader('traceparent') && ($tp = $tracer->traceparent()) !== null) {

--- a/src/VigilanceServiceProvider.php
+++ b/src/VigilanceServiceProvider.php
@@ -63,6 +63,7 @@ use Vigilance\Contracts\RunRepository;
 use Vigilance\Control\ControlGate;
 use Vigilance\Events\ExceptionReported;
 use Vigilance\Http\Controllers\AssetController;
+use Vigilance\Http\Controllers\FeedbackController;
 use Vigilance\Http\Controllers\RumController;
 use Vigilance\Http\Livewire\Apm as ApmPage;
 use Vigilance\Http\Livewire\ApmCard;
@@ -246,6 +247,7 @@ class VigilanceServiceProvider extends ServiceProvider
         $this->registerAssets();
         $this->registerRoutes();
         $this->registerRum();
+        $this->registerFeedback();
         $this->registerLivewire();
         $this->registerCommands();
         $this->registerAbout();
@@ -663,6 +665,22 @@ class VigilanceServiceProvider extends ServiceProvider
             'as' => 'vigilance.rum.',
         ], function () {
             Route::post('rum', [RumController::class, 'store'])->name('store');
+        });
+    }
+
+    protected function registerFeedback(): void
+    {
+        if (! config('vigilance.feedback.enabled', false)) {
+            return;
+        }
+
+        Route::group([
+            'domain' => config('vigilance.domain'),
+            'prefix' => config('vigilance.path', 'vigilance'),
+            'middleware' => ['throttle:'.config('vigilance.feedback.throttle', '30,1')],
+            'as' => 'vigilance.feedback.',
+        ], function () {
+            Route::post('feedback', [FeedbackController::class, 'store'])->name('store');
         });
     }
 

--- a/src/VigilanceServiceProvider.php
+++ b/src/VigilanceServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Http\Client\Factory;
+use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Events\JobFailed;
@@ -95,6 +96,7 @@ use Vigilance\Logs\Storage\DatabaseLogStorage;
 use Vigilance\Mcp\VigilanceServer;
 use Vigilance\Storage\DatabaseMetricsRepository;
 use Vigilance\Storage\DatabaseRunRepository;
+use Vigilance\Support\Breadcrumbs;
 use Vigilance\Tracing\Contracts\TraceStorage;
 use Vigilance\Tracing\Middleware\TraceRequests;
 use Vigilance\Tracing\Sampling\Sampler;
@@ -110,6 +112,10 @@ class VigilanceServiceProvider extends ServiceProvider
         $this->app->singleton(RunRepository::class, DatabaseRunRepository::class);
         $this->app->singleton(MetricsRepository::class, DatabaseMetricsRepository::class);
         $this->app->singleton(Recorder::class);
+        $this->app->singleton(
+            Breadcrumbs::class,
+            fn ($app) => new Breadcrumbs((int) $app['config']->get('vigilance.issues.breadcrumbs.max', 25)),
+        );
 
         $this->registerApm();
         $this->registerLogs();
@@ -232,6 +238,7 @@ class VigilanceServiceProvider extends ServiceProvider
 
             if (config('vigilance.issues.enabled', true)) {
                 $this->registerIssueCapture();
+                $this->registerBreadcrumbs();
             }
         }
 
@@ -344,6 +351,42 @@ class VigilanceServiceProvider extends ServiceProvider
             ExceptionReported::class,
             fn ($event) => $capture->capture($event->exception, 'reported'),
         );
+    }
+
+    /**
+     * Feed the breadcrumb trail: record log lines automatically (so an error's
+     * issue shows the logs that preceded it) and clear the trail at each job
+     * boundary. Request boundaries are handled by Vigilance::flushState().
+     */
+    protected function registerBreadcrumbs(): void
+    {
+        if (! config('vigilance.issues.breadcrumbs.enabled', true)) {
+            return;
+        }
+
+        $events = $this->app->make('events');
+
+        if (config('vigilance.issues.breadcrumbs.log', true)) {
+            $events->listen(MessageLogged::class, function ($event): void {
+                try {
+                    $this->app->make(Breadcrumbs::class)->add(
+                        (string) $event->message,
+                        category: 'log',
+                        level: (string) $event->level,
+                    );
+                } catch (\Throwable) {
+                    //
+                }
+            });
+        }
+
+        $events->listen(JobProcessing::class, function (): void {
+            try {
+                $this->app->make(Breadcrumbs::class)->clear();
+            } catch (\Throwable) {
+                //
+            }
+        });
     }
 
     protected function bootTracing(): void

--- a/src/VigilanceServiceProvider.php
+++ b/src/VigilanceServiceProvider.php
@@ -23,6 +23,7 @@ use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Redis\Events\CommandExecuted;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Mcp\Facades\Mcp;
@@ -411,10 +412,17 @@ class VigilanceServiceProvider extends ServiceProvider
 
         if (config('vigilance.tracing.capture.jobs', true)) {
             $events->listen(JobProcessing::class, fn ($e) => $tracer->rescue(
-                fn () => $tracer->start('job', $e->job->resolveName(), null, [
-                    'connection' => $e->connectionName,
-                    'queue' => $e->job->getQueue(),
-                ])
+                function () use ($tracer, $e) {
+                    // Continue the trace from the request/job that dispatched this
+                    // one (the traceparent is carried on the job payload), so the
+                    // job links back to what enqueued it across the queue boundary.
+                    $tracer->continueFrom($e->job->payload()['vigilance_traceparent'] ?? null);
+
+                    $tracer->start('job', $e->job->resolveName(), null, [
+                        'connection' => $e->connectionName,
+                        'queue' => $e->job->getQueue(),
+                    ]);
+                }
             ));
             $events->listen(JobProcessed::class, fn () => $tracer->finish('ok'));
             $events->listen(JobFailed::class, fn () => $tracer->finish('error'));
@@ -430,6 +438,24 @@ class VigilanceServiceProvider extends ServiceProvider
             $events->listen(CommandFinished::class, fn ($e) => $tracer->finish(
                 ((int) ($e->exitCode ?? 0)) !== 0 ? 'error' : 'ok'
             ));
+        }
+
+        // --- Distributed propagation --------------------------------------
+        // Emit a W3C traceparent on outgoing HTTP so downstream services can
+        // continue the trace. Guarded and only when a trace is in flight.
+        if (config('vigilance.tracing.propagation', true)
+            && method_exists(Http::class, 'globalRequestMiddleware')) {
+            Http::globalRequestMiddleware(function ($request) use ($tracer) {
+                try {
+                    if (! $request->hasHeader('traceparent') && ($tp = $tracer->traceparent()) !== null) {
+                        return $request->withHeader('traceparent', $tp);
+                    }
+                } catch (\Throwable) {
+                    // Propagation is best-effort; never break the outgoing call.
+                }
+
+                return $request;
+            });
         }
 
         // --- Child spans ---------------------------------------------------

--- a/src/VigilanceServiceProvider.php
+++ b/src/VigilanceServiceProvider.php
@@ -46,6 +46,7 @@ use Vigilance\Console\DeployCommand;
 use Vigilance\Console\DoctorCommand;
 use Vigilance\Console\HealthCommand;
 use Vigilance\Console\InstallCommand;
+use Vigilance\Console\MaintenanceCommand;
 use Vigilance\Console\PauseCommand;
 use Vigilance\Console\PruneCommand;
 use Vigilance\Console\RestartCommand;
@@ -686,6 +687,7 @@ class VigilanceServiceProvider extends ServiceProvider
             DeployCommand::class,
             HealthCommand::class,
             SourcemapCommand::class,
+            MaintenanceCommand::class,
         ], 'class_exists');
 
         $this->commands($commands);

--- a/tests/Feature/BreadcrumbsTest.php
+++ b/tests/Feature/BreadcrumbsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Vigilance\Capture\IssueCapture;
+use Vigilance\Models\FailureGroup;
+use Vigilance\Support\Breadcrumbs;
+use Vigilance\Vigilance;
+
+uses(RefreshDatabase::class);
+
+beforeEach(fn () => app(Breadcrumbs::class)->clear());
+
+it('rings the buffer at the configured max', function () {
+    $crumbs = new Breadcrumbs(max: 3);
+
+    foreach (['a', 'b', 'c', 'd', 'e'] as $m) {
+        $crumbs->add($m);
+    }
+
+    expect($crumbs->all())->toHaveCount(3)
+        ->and(array_column($crumbs->all(), 'message'))->toBe(['c', 'd', 'e']);
+});
+
+it('records breadcrumbs through the Vigilance API and redacts data', function () {
+    Vigilance::breadcrumb('Charged card', 'billing', data: ['amount' => 20, 'token' => 'secret-abc']);
+
+    $all = app(Breadcrumbs::class)->all();
+
+    expect($all)->toHaveCount(1)
+        ->and($all[0]['message'])->toBe('Charged card')
+        ->and($all[0]['category'])->toBe('billing')
+        ->and($all[0]['data']['amount'])->toBe(20)
+        ->and($all[0]['data']['token'])->not->toBe('secret-abc'); // redacted
+});
+
+it('auto-records log lines as breadcrumbs', function () {
+    Log::info('User signed in');
+    Log::warning('Rate limit near');
+
+    $messages = array_column(app(Breadcrumbs::class)->all(), 'message');
+
+    expect($messages)->toContain('User signed in')
+        ->and($messages)->toContain('Rate limit near')
+        ->and(collect(app(Breadcrumbs::class)->all())->firstWhere('message', 'User signed in')['category'])->toBe('log');
+});
+
+it('attaches the trail to an issue when an exception is captured', function () {
+    Vigilance::breadcrumb('Loaded order #42', 'order');
+    Log::error('Payment gateway timeout');
+
+    app(IssueCapture::class)->capture(new RuntimeException('boom'), 'reported');
+
+    $group = FailureGroup::query()->where('exception_class', RuntimeException::class)->first();
+
+    expect($group)->not->toBeNull()
+        ->and($group->context)->toHaveKey('breadcrumbs');
+
+    $messages = array_column($group->context['breadcrumbs'], 'message');
+    expect($messages)->toContain('Loaded order #42')
+        ->and($messages)->toContain('Payment gateway timeout');
+});
+
+it('clears the trail on the request/worker boundary', function () {
+    Vigilance::breadcrumb('before');
+    expect(app(Breadcrumbs::class)->all())->toHaveCount(1);
+
+    Vigilance::flushState();
+
+    expect(app(Breadcrumbs::class)->all())->toBe([]);
+});

--- a/tests/Feature/ControlTest.php
+++ b/tests/Feature/ControlTest.php
@@ -203,3 +203,32 @@ it('retries a failed job from its stored payload and audits it', function () {
     expect(Run::query()->where('name', SampleJob::class)->where('status', RunStatus::Succeeded->value)->count())
         ->toBeGreaterThanOrEqual(1);
 });
+
+it('links a manually retried run to its parent via retry_of', function () {
+    config()->set('vigilance.control.jobs', [
+        'mode' => 'list', 'paths' => [], 'allow' => [SampleJob::class], 'deny' => [],
+    ]);
+    ControlGate::flush();
+
+    (new JobDispatcher)->dispatch(SampleJob::class, ['amount' => '1'], queued: false, user: 'admin@test');
+    $original = Run::query()->where('name', SampleJob::class)->latest('id')->first();
+    $original->forceFill([
+        'status' => RunStatus::Failed->value,
+        'payload_raw' => serialize(new SampleJob(1)),
+    ])->save();
+
+    (new JobRetrier)->retry($original->id, user: 'admin@test');
+
+    // The capture layer read the lineage marker at dispatch time and linked the
+    // fresh run back to the one it retried.
+    $child = Run::query()
+        ->where('name', SampleJob::class)
+        ->where('id', '>', $original->id)
+        ->whereNotNull('retry_of')
+        ->latest('id')
+        ->first();
+
+    expect($child)->not->toBeNull()
+        ->and($child->retry_of)->toBe($original->id)
+        ->and($original->fresh()->retries)->toHaveCount(1);
+});

--- a/tests/Feature/CustomMetricsRichnessTest.php
+++ b/tests/Feature/CustomMetricsRichnessTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Carbon\CarbonInterval;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vigilance\Apm\Apm;
+use Vigilance\Metrics\CustomMetrics;
+use Vigilance\Vigilance;
+
+uses(RefreshDatabase::class);
+
+it('records a distribution metric with percentiles', function () {
+    foreach ([10, 20, 30, 40, 50, 60, 70, 80, 90, 1000] as $ms) {
+        Vigilance::timing('checkout_ms', $ms);
+    }
+    app(Apm::class)->ingest();
+
+    $dist = app(CustomMetrics::class)->all(CarbonInterval::hour())->firstWhere('name', 'checkout_ms');
+
+    expect($dist)->not->toBeNull()
+        ->and($dist->type)->toBe('distribution')
+        ->and($dist->p50)->not->toBeNull()
+        ->and($dist->p95)->toBeGreaterThanOrEqual($dist->p50)
+        ->and($dist->p99)->toBeGreaterThanOrEqual($dist->p95)
+        ->and($dist->peak)->toBe(1000); // the outlier is the max
+});
+
+it('decrements a counter through the same series', function () {
+    Vigilance::increment('active_sessions', 5);
+    Vigilance::decrement('active_sessions', 2);
+    app(Apm::class)->ingest();
+
+    $counter = app(CustomMetrics::class)->all(CarbonInterval::hour())->firstWhere('name', 'active_sessions');
+
+    expect($counter)->not->toBeNull()
+        ->and($counter->type)->toBe('count')
+        ->and($counter->value)->toBe(3);
+});

--- a/tests/Feature/IssueMergeTest.php
+++ b/tests/Feature/IssueMergeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Vigilance\Capture\FailureGrouper;
+use Vigilance\Control\IssueMerger;
+use Vigilance\Enums\RunStatus;
+use Vigilance\Enums\RunType;
+use Vigilance\Models\FailureGroup;
+use Vigilance\Models\Run;
+
+uses(RefreshDatabase::class);
+
+function seedFailureRun(int $groupId): void
+{
+    Run::query()->create([
+        'uuid' => (string) Str::uuid(),
+        'type' => RunType::Job->value,
+        'name' => 'App\\Jobs\\Demo',
+        'status' => RunStatus::Failed->value,
+        'failure_group_id' => $groupId,
+    ]);
+}
+
+it('merges a source issue into a target, moving runs and occurrences', function () {
+    $grouper = app(FailureGrouper::class);
+    $a = $grouper->record('job', 'A', 'RuntimeException', 'boom A');
+    $b = $grouper->record('job', 'B', 'RuntimeException', 'boom B');
+    seedFailureRun($b);
+
+    $result = app(IssueMerger::class)->merge($b, $a, 'me@test');
+
+    $groupA = FailureGroup::find($a);
+    $groupB = FailureGroup::find($b);
+
+    expect($result['merged_into'])->toBe($a)
+        ->and($groupB->merged_into)->toBe($a)
+        ->and($groupB->resolved_at)->not->toBeNull()
+        ->and(Run::query()->where('failure_group_id', $b)->count())->toBe(0)
+        ->and(Run::query()->where('failure_group_id', $a)->count())->toBe(1)
+        ->and($groupA->occurrences)->toBe(2); // 1 (A) + 1 (B)
+
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'merge_issue', 'user' => 'me@test']);
+});
+
+it('redirects future occurrences of a merged signature to the target', function () {
+    $grouper = app(FailureGrouper::class);
+    $a = $grouper->record('job', 'A', 'RuntimeException', 'boom A');
+    $b = $grouper->record('job', 'B', 'RuntimeException', 'boom B');
+
+    app(IssueMerger::class)->merge($b, $a);
+
+    // The same error that used to hit B now lands on A.
+    $grouper->record('job', 'B', 'RuntimeException', 'boom B');
+
+    expect(FailureGroup::find($a)->occurrences)->toBe(3)  // 1 + 1 (merged) + 1 (redirected)
+        ->and(FailureGroup::find($b)->occurrences)->toBe(1); // unchanged
+});
+
+it('refuses to merge an issue into itself', function () {
+    $grouper = app(FailureGrouper::class);
+    $a = $grouper->record('job', 'A', 'RuntimeException', 'boom A');
+
+    expect(fn () => app(IssueMerger::class)->merge($a, $a))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Feature/JobCapabilityTagsTest.php
+++ b/tests/Feature/JobCapabilityTagsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Vigilance\Capture\TagExtractor;
+
+it('tags jobs with their queue capabilities', function () {
+    $unique = new class implements ShouldBeUnique {};
+    $encrypted = new class implements ShouldBeEncrypted {};
+    $plain = new class {};
+
+    expect(TagExtractor::for($unique))->toContain('unique')
+        ->and(TagExtractor::for($encrypted))->toContain('encrypted')
+        ->and(TagExtractor::for($plain))->not->toContain('unique')
+        ->and(TagExtractor::for($plain))->not->toContain('encrypted');
+});

--- a/tests/Feature/JobCapabilityTagsTest.php
+++ b/tests/Feature/JobCapabilityTagsTest.php
@@ -14,3 +14,16 @@ it('tags jobs with their queue capabilities', function () {
         ->and(TagExtractor::for($plain))->not->toContain('unique')
         ->and(TagExtractor::for($plain))->not->toContain('encrypted');
 });
+
+it('derives capability tags from a class name alone (for opaque encrypted jobs)', function () {
+    // An encrypted job's command object cannot be reconstructed at capture time,
+    // so tagging must work from the class name — the case that most needs it.
+    $encrypted = new class implements ShouldBeEncrypted {};
+    $unique = new class implements ShouldBeUnique {};
+
+    expect(TagExtractor::forClass($encrypted::class))->toBe(['encrypted'])
+        ->and(TagExtractor::forClass($unique::class))->toBe(['unique'])
+        ->and(TagExtractor::forClass(stdClass::class))->toBe([])
+        ->and(TagExtractor::forClass('Nonexistent\\Class'))->toBe([])
+        ->and(TagExtractor::forClass(null))->toBe([]);
+});

--- a/tests/Feature/LongRunningJobRuleTest.php
+++ b/tests/Feature/LongRunningJobRuleTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Vigilance\Enums\RunStatus;
+use Vigilance\Enums\RunType;
+use Vigilance\Models\Run;
+use Vigilance\Notifications\AlertManager;
+use Vigilance\Vigilance;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    foreach (['queue_long_wait', 'error_rate', 'exception_spike', 'slow_request_rate', 'scheduled_task_late'] as $rule) {
+        config()->set("vigilance.alerts.rules.$rule.enabled", false);
+    }
+    config()->set('vigilance.alerts.rules.long_running_job', ['enabled' => true, 'seconds' => 300, 'limit' => 10]);
+});
+
+function runningJob(int $agoSeconds): Run
+{
+    return Run::query()->create([
+        'uuid' => (string) Str::uuid(),
+        'type' => RunType::Job->value,
+        'name' => 'App\\Jobs\\SlowReport',
+        'status' => RunStatus::Running->value,
+        'queue' => 'reports',
+        'connection_name' => 'redis',
+        'started_at' => Carbon::now()->subSeconds($agoSeconds),
+    ]);
+}
+
+it('alerts on a job stuck running past the threshold', function () {
+    runningJob(600); // 10 min, over the 5 min threshold
+
+    $captured = [];
+    Vigilance::alertUsing(function ($a) use (&$captured) {
+        $captured[] = $a->key;
+    });
+
+    expect(app(AlertManager::class)->check())->toBe(1)
+        ->and($captured[0])->toStartWith('long_running_job:');
+});
+
+it('does not alert on a job within the threshold or already finished', function () {
+    runningJob(60); // recent
+    Run::query()->create([
+        'uuid' => (string) Str::uuid(),
+        'type' => RunType::Job->value,
+        'name' => 'App\\Jobs\\Done',
+        'status' => RunStatus::Succeeded->value,
+        'started_at' => Carbon::now()->subSeconds(900),
+        'finished_at' => Carbon::now(),
+    ]);
+
+    expect(app(AlertManager::class)->check())->toBe(0);
+});
+
+it('is off unless enabled', function () {
+    config()->set('vigilance.alerts.rules.long_running_job.enabled', false);
+    runningJob(600);
+
+    expect(app(AlertManager::class)->check())->toBe(0);
+});

--- a/tests/Feature/MaintenanceWindowTest.php
+++ b/tests/Feature/MaintenanceWindowTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Vigilance\Enums\RunStatus;
+use Vigilance\Enums\RunType;
+use Vigilance\Models\Run;
+use Vigilance\Notifications\AlertManager;
+use Vigilance\Notifications\MaintenanceWindow;
+use Vigilance\Vigilance;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Cache::store()->forget('vigilance:maintenance:until');
+    config()->set('vigilance.notifications.maintenance', []);
+    foreach (['queue_long_wait', 'error_rate', 'exception_spike', 'slow_request_rate', 'scheduled_task_late'] as $rule) {
+        config()->set("vigilance.alerts.rules.$rule.enabled", false);
+    }
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+function seedErrorRun(string $status): void
+{
+    Run::query()->create([
+        'uuid' => (string) Str::uuid(),
+        'type' => RunType::Job->value,
+        'name' => 'App\\Jobs\\Demo',
+        'status' => $status,
+    ]);
+}
+
+it('opens and closes an ad-hoc window', function () {
+    $m = app(MaintenanceWindow::class);
+
+    expect($m->active())->toBeFalse();
+
+    $until = $m->start(30);
+    expect($m->active())->toBeTrue()
+        ->and($m->adHocUntil())->toBe($until)
+        ->and($until)->toBeGreaterThan(time());
+
+    $m->stop();
+    expect($m->active())->toBeFalse()
+        ->and($m->adHocUntil())->toBeNull();
+});
+
+it('auto-expires a lapsed ad-hoc window', function () {
+    Cache::store()->forever('vigilance:maintenance:until', time() - 5);
+
+    expect(app(MaintenanceWindow::class)->active())->toBeFalse();
+});
+
+it('matches a recurring config window (incl. midnight wrap)', function () {
+    config()->set('vigilance.notifications.maintenance', [
+        ['days' => ['sun'], 'from' => '02:00', 'to' => '03:00'],
+        ['from' => '23:00', 'to' => '01:00'], // wraps midnight, every day
+    ]);
+
+    $m = app(MaintenanceWindow::class);
+
+    Carbon::setTestNow(Carbon::parse('2026-07-19 02:30:00')); // Sunday
+    expect($m->active())->toBeTrue();
+
+    Carbon::setTestNow(Carbon::parse('2026-07-20 02:30:00')); // Monday, outside sun window
+    expect($m->active())->toBeFalse();
+
+    Carbon::setTestNow(Carbon::parse('2026-07-20 23:30:00')); // inside wrap window
+    expect($m->active())->toBeTrue();
+
+    Carbon::setTestNow(Carbon::parse('2026-07-20 00:30:00')); // still inside wrap (after midnight)
+    expect($m->active())->toBeTrue();
+});
+
+it('suppresses alert notifications while a window is active', function () {
+    config()->set('vigilance.alerts.rules.error_rate', ['enabled' => true, 'min_runs' => 2, 'percent' => 10]);
+
+    $captured = [];
+    Vigilance::alertUsing(function ($alert) use (&$captured) {
+        $captured[] = $alert->key;
+    });
+
+    seedErrorRun(RunStatus::Succeeded->value);
+    seedErrorRun(RunStatus::Failed->value);
+    seedErrorRun(RunStatus::Failed->value);
+
+    // Window open → nothing pages.
+    app(MaintenanceWindow::class)->start(30);
+    expect(app(AlertManager::class)->check())->toBe(0)
+        ->and($captured)->toBe([]);
+
+    // Window closed → the still-breaching condition notifies.
+    app(MaintenanceWindow::class)->stop();
+    expect(app(AlertManager::class)->check())->toBe(1)
+        ->and($captured)->toContain('error_rate');
+});
+
+it('toggles maintenance from the artisan command', function () {
+    $this->artisan('vigilance:maintenance', ['--minutes' => 10])->assertSuccessful();
+    expect(app(MaintenanceWindow::class)->active())->toBeTrue();
+
+    $this->artisan('vigilance:maintenance', ['--status' => true])->assertSuccessful();
+
+    $this->artisan('vigilance:maintenance', ['--off' => true])->assertSuccessful();
+    expect(app(MaintenanceWindow::class)->active())->toBeFalse();
+});

--- a/tests/Feature/NPlusOneRuleTest.php
+++ b/tests/Feature/NPlusOneRuleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vigilance\Apm\Apm;
+use Vigilance\Notifications\AlertManager;
+use Vigilance\Vigilance;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    foreach (['queue_long_wait', 'error_rate', 'exception_spike', 'slow_request_rate', 'scheduled_task_late'] as $rule) {
+        config()->set("vigilance.alerts.rules.$rule.enabled", false);
+    }
+    config()->set('vigilance.alerts.rules.n_plus_one', ['enabled' => true, 'min_occurrences' => 2, 'window' => '1h']);
+});
+
+it('alerts on recurring N+1 patterns', function () {
+    app(Apm::class)->record('n_plus_one', 'GET /list', 10)->count()->max();
+    app(Apm::class)->record('n_plus_one', 'GET /list', 14)->count()->max();
+    app(Apm::class)->ingest();
+
+    $captured = [];
+    Vigilance::alertUsing(function ($a) use (&$captured) {
+        $captured[] = $a->key;
+    });
+
+    expect(app(AlertManager::class)->check())->toBe(1)
+        ->and($captured)->toContain('n_plus_one:GET /list');
+});
+
+it('stays quiet below the minimum occurrences', function () {
+    app(Apm::class)->record('n_plus_one', 'GET /list', 10)->count()->max();
+    app(Apm::class)->ingest();
+
+    expect(app(AlertManager::class)->check())->toBe(0);
+});

--- a/tests/Feature/UserFeedbackTest.php
+++ b/tests/Feature/UserFeedbackTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Vigilance\Http\Controllers\FeedbackController;
+use Vigilance\Models\UserFeedback;
+use Vigilance\Tracing\Tracer;
+
+uses(RefreshDatabase::class);
+
+function callFeedback(array $payload): void
+{
+    $request = Request::create('/vigilance/feedback', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode($payload));
+
+    app(FeedbackController::class)->store($request, app(Tracer::class));
+}
+
+it('stores user feedback when enabled', function () {
+    config()->set('vigilance.feedback.enabled', true);
+
+    callFeedback(['message' => 'The export is slow', 'email' => 'user@example.com', 'url' => '/reports', 'trace_id' => 'abc123']);
+
+    $feedback = UserFeedback::query()->first();
+
+    expect($feedback)->not->toBeNull()
+        ->and($feedback->message)->toBe('The export is slow')
+        ->and($feedback->email)->toBe('user@example.com')
+        ->and($feedback->url)->toBe('/reports')
+        ->and($feedback->trace_id)->toBe('abc123');
+});
+
+it('ignores empty messages', function () {
+    config()->set('vigilance.feedback.enabled', true);
+
+    callFeedback(['message' => '   ']);
+
+    expect(UserFeedback::query()->count())->toBe(0);
+});
+
+it('is a 404 when disabled', function () {
+    config()->set('vigilance.feedback.enabled', false);
+
+    expect(fn () => callFeedback(['message' => 'hi']))->toThrow(NotFoundHttpException::class);
+    expect(UserFeedback::query()->count())->toBe(0);
+});

--- a/tests/Mcp/AddedToolsTest.php
+++ b/tests/Mcp/AddedToolsTest.php
@@ -2,10 +2,12 @@
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Vigilance\Mcp\Tools\AssignIssueTool;
+use Vigilance\Mcp\Tools\MaintenanceTool;
 use Vigilance\Mcp\Tools\RecordDeployTool;
 use Vigilance\Mcp\Tools\RoutesTool;
 use Vigilance\Mcp\Tools\WorkloadTool;
 use Vigilance\Models\Deployment;
+use Vigilance\Notifications\MaintenanceWindow;
 
 uses(RefreshDatabase::class);
 
@@ -55,4 +57,20 @@ it('assigns and unassigns an issue over mcp', function () {
     expect($issue->fresh()->assignee)->toBeNull();
 
     $this->assertDatabaseHas('vigilance_audit', ['action' => 'assign_issue']);
+});
+
+it('starts, reports and stops maintenance over mcp', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+
+    $this->tool(MaintenanceTool::class, ['action' => 'start', 'minutes' => 15])
+        ->assertOk()
+        ->assertSee('until');
+    expect(app(MaintenanceWindow::class)->active())->toBeTrue();
+
+    $this->tool(MaintenanceTool::class, ['action' => 'status'])->assertOk()->assertSee('suppressed');
+
+    $this->tool(MaintenanceTool::class, ['action' => 'stop'])->assertOk();
+    expect(app(MaintenanceWindow::class)->active())->toBeFalse();
+
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'maintenance_start']);
 });

--- a/tests/Mcp/AddedToolsTest.php
+++ b/tests/Mcp/AddedToolsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Vigilance\Mcp\Tools\AssignIssueTool;
 use Vigilance\Mcp\Tools\MaintenanceTool;
+use Vigilance\Mcp\Tools\MergeIssuesTool;
 use Vigilance\Mcp\Tools\RecordDeployTool;
 use Vigilance\Mcp\Tools\RoutesTool;
 use Vigilance\Mcp\Tools\WorkloadTool;
@@ -73,4 +74,17 @@ it('starts, reports and stops maintenance over mcp', function () {
     expect(app(MaintenanceWindow::class)->active())->toBeFalse();
 
     $this->assertDatabaseHas('vigilance_audit', ['action' => 'maintenance_start']);
+});
+
+it('merges two issues over mcp', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+    $a = $this->seedIssue();
+    $b = $this->seedIssue();
+
+    $this->tool(MergeIssuesTool::class, ['from' => $b->id, 'into' => $a->id])
+        ->assertOk()
+        ->assertSee('merged_into');
+
+    expect($b->fresh()->merged_into)->toBe($a->id);
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'merge_issue']);
 });

--- a/tests/Mcp/AddedToolsTest.php
+++ b/tests/Mcp/AddedToolsTest.php
@@ -2,12 +2,14 @@
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Vigilance\Mcp\Tools\AssignIssueTool;
+use Vigilance\Mcp\Tools\FeedbackTool;
 use Vigilance\Mcp\Tools\MaintenanceTool;
 use Vigilance\Mcp\Tools\MergeIssuesTool;
 use Vigilance\Mcp\Tools\RecordDeployTool;
 use Vigilance\Mcp\Tools\RoutesTool;
 use Vigilance\Mcp\Tools\WorkloadTool;
 use Vigilance\Models\Deployment;
+use Vigilance\Models\UserFeedback;
 use Vigilance\Notifications\MaintenanceWindow;
 
 uses(RefreshDatabase::class);
@@ -74,6 +76,18 @@ it('starts, reports and stops maintenance over mcp', function () {
     expect(app(MaintenanceWindow::class)->active())->toBeFalse();
 
     $this->assertDatabaseHas('vigilance_audit', ['action' => 'maintenance_start']);
+});
+
+it('lists user feedback over mcp', function () {
+    UserFeedback::query()->create([
+        'message' => 'The export is broken',
+        'trace_id' => 'abc123',
+        'created_at' => now(),
+    ]);
+
+    $this->tool(FeedbackTool::class, [])
+        ->assertOk()
+        ->assertSee('The export is broken');
 });
 
 it('merges two issues over mcp', function () {

--- a/tests/Mcp/AddedToolsTest.php
+++ b/tests/Mcp/AddedToolsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vigilance\Mcp\Tools\AssignIssueTool;
+use Vigilance\Mcp\Tools\RecordDeployTool;
+use Vigilance\Mcp\Tools\RoutesTool;
+use Vigilance\Mcp\Tools\WorkloadTool;
+use Vigilance\Models\Deployment;
+
+uses(RefreshDatabase::class);
+
+it('routes tool runs read-only and returns a route list', function () {
+    $this->tool(RoutesTool::class, ['window' => '1h'])
+        ->assertOk()
+        ->assertSee('routes');
+});
+
+it('workload tool returns system load and job-class breakdown', function () {
+    $this->tool(WorkloadTool::class, [])
+        ->assertOk()
+        ->assertSee('job_classes');
+});
+
+it('record-deploy is hidden/refused without writes', function () {
+    config()->set('vigilance.mcp.allow_writes', false);
+
+    $this->tool(RecordDeployTool::class, ['release' => 'v1.0.0'])->assertHasErrors();
+
+    expect(Deployment::query()->count())->toBe(0);
+});
+
+it('records a deployment over mcp and audits it', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+
+    $this->tool(RecordDeployTool::class, ['release' => 'v1.2.3', 'commit' => 'abc1234'])
+        ->assertOk()
+        ->assertSee('v1.2.3');
+
+    expect(Deployment::query()->where('version', 'v1.2.3')->exists())->toBeTrue();
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'record_deploy', 'user' => 'mcp']);
+});
+
+it('assigns and unassigns an issue over mcp', function () {
+    config()->set('vigilance.mcp.allow_writes', true);
+    $issue = $this->seedIssue();
+
+    $this->tool(AssignIssueTool::class, ['id' => $issue->id, 'assignee' => 'dev@team'])
+        ->assertOk()
+        ->assertSee('assigned');
+    expect($issue->fresh()->assignee)->toBe('dev@team');
+
+    $this->tool(AssignIssueTool::class, ['id' => $issue->id, 'assignee' => ''])
+        ->assertOk()
+        ->assertSee('unassigned');
+    expect($issue->fresh()->assignee)->toBeNull();
+
+    $this->assertDatabaseHas('vigilance_audit', ['action' => 'assign_issue']);
+});

--- a/tests/Tracing/DistributedTracingTest.php
+++ b/tests/Tracing/DistributedTracingTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Vigilance\Capture\Recorder;
+use Vigilance\Tracing\Contracts\TraceStorage;
+use Vigilance\Tracing\Tracer;
+
+uses(RefreshDatabase::class);
+
+it('builds a valid W3C traceparent for the in-flight trace', function () {
+    $tracer = app(Tracer::class);
+
+    expect($tracer->traceparent())->toBeNull(); // no trace yet
+
+    $tracer->start('job', 'demo');
+    $tp = $tracer->traceparent();
+
+    expect($tp)->toMatch('/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/');
+    $tracer->finish('ok');
+});
+
+it('continues an upstream trace across a start (parent recorded)', function () {
+    $tracer = app(Tracer::class);
+
+    // A parent produced by an upstream unit.
+    $tracer->start('request', 'GET /up');
+    $parentTp = $tracer->traceparent();
+    $parentId = $tracer->currentTraceId();
+    $tracer->finish('ok');
+
+    // A downstream unit continues from it.
+    expect($tracer->continueFrom($parentTp))->toBeTrue();
+    $tracer->start('job', 'downstream');
+    $tracer->finish('ok');
+
+    $trace = collect(app(TraceStorage::class)->recent())->firstWhere('name', 'downstream');
+    $full = app(TraceStorage::class)->find($trace->id);
+
+    expect($full->attributes)->toHaveKey('parent_trace_id')
+        ->and($full->attributes['parent_trace_id'])->toBe(str_replace('-', '', $parentId));
+});
+
+it('rejects invalid and all-zero traceparents', function () {
+    $tracer = app(Tracer::class);
+
+    expect($tracer->continueFrom(null))->toBeFalse()
+        ->and($tracer->continueFrom('garbage'))->toBeFalse()
+        ->and($tracer->continueFrom('00-'.str_repeat('0', 32).'-'.str_repeat('0', 16).'-01'))->toBeFalse()
+        ->and($tracer->continueFrom('00-'.str_repeat('a', 32).'-'.str_repeat('b', 16).'-01'))->toBeTrue();
+});
+
+it('does not continue when propagation is disabled', function () {
+    config()->set('vigilance.tracing.propagation', false);
+
+    expect(app(Tracer::class)->continueFrom('00-'.str_repeat('a', 32).'-'.str_repeat('b', 16).'-01'))->toBeFalse();
+});
+
+it('continues an incoming HTTP traceparent header end-to-end', function () {
+    Route::get('/_dt_probe', fn () => 'ok');
+
+    $trace = '4bf92f3577b34da6a3ce929d0e0e4736';
+    $this->get('/_dt_probe', ['traceparent' => "00-{$trace}-00f067aa0ba902b7-01"])->assertOk();
+
+    $row = app(TraceStorage::class)->recent()->first();
+    $full = app(TraceStorage::class)->find($row->id);
+
+    expect($full->attributes['parent_trace_id'] ?? null)->toBe($trace);
+});
+
+it('injects the trace context onto a dispatched job payload', function () {
+    $tracer = app(Tracer::class);
+    $tracer->start('request', 'GET /dispatcher');
+
+    $out = app(Recorder::class)->onJobPayloadCreate('database', 'default', [
+        'uuid' => 'abc',
+        'displayName' => 'App\\Jobs\\Demo',
+        'data' => ['commandName' => 'App\\Jobs\\Demo', 'command' => 'x'],
+    ]);
+
+    expect($out)->toHaveKey('vigilance_traceparent')
+        ->and($out['vigilance_traceparent'])->toMatch('/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/');
+
+    $tracer->finish('ok');
+});

--- a/tests/Tracing/DistributedTracingTest.php
+++ b/tests/Tracing/DistributedTracingTest.php
@@ -1,12 +1,46 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 use Vigilance\Capture\Recorder;
 use Vigilance\Tracing\Contracts\TraceStorage;
 use Vigilance\Tracing\Tracer;
 
 uses(RefreshDatabase::class);
+
+it('emits a traceparent on outgoing HTTP while a trace is live', function () {
+    // Regression guard: the global HTTP request middleware must actually be
+    // registered (a method_exists() probe on the Http *facade* is always false
+    // and would silently disable this).
+    Http::fake(['*' => Http::response(['ok' => true])]);
+
+    $tracer = app(Tracer::class);
+    $tracer->start('request', 'GET /outbound');
+    Http::get('https://api.example.com/things');
+    $tracer->finish('ok');
+
+    $sent = null;
+    Http::recorded(function ($request) use (&$sent) {
+        $sent = $request->header('traceparent');
+    });
+
+    expect($sent)->toBeArray()->not->toBeEmpty()
+        ->and($sent[0])->toMatch('/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/');
+});
+
+it('does not emit a traceparent when no trace is active', function () {
+    Http::fake(['*' => Http::response(['ok' => true])]);
+
+    Http::get('https://api.example.com/things'); // no trace started
+
+    $sent = 'unset';
+    Http::recorded(function ($request) use (&$sent) {
+        $sent = $request->header('traceparent');
+    });
+
+    expect($sent)->toBe([]); // header absent
+});
 
 it('builds a valid W3C traceparent for the in-flight trace', function () {
     $tracer = app(Tracer::class);

--- a/tests/Tracing/NPlusOneSignalTest.php
+++ b/tests/Tracing/NPlusOneSignalTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Carbon\CarbonInterval;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Vigilance\Apm\Apm;
+use Vigilance\Apm\Contracts\Storage;
+use Vigilance\Tracing\Tracer;
+
+uses(RefreshDatabase::class);
+
+it('promotes a detected N+1 to an aggregatable APM signal', function () {
+    config()->set('vigilance.tracing.n_plus_one_threshold', 3);
+
+    $tracer = app(Tracer::class);
+    $tracer->start('request', 'GET /list');
+
+    $t = microtime(true);
+    for ($i = 0; $i < 4; $i++) {
+        $tracer->span('query', 'select * from users where id = ?', $t, $t + 0.001);
+    }
+    $tracer->finish('ok');
+
+    app(Apm::class)->ingest();
+
+    $row = collect(app(Storage::class)->aggregate('n_plus_one', ['count', 'max'], CarbonInterval::hour()))
+        ->firstWhere('key', 'GET /list');
+
+    expect($row)->not->toBeNull()
+        ->and((int) $row->max)->toBe(4);
+});
+
+it('does not record an N+1 signal below the threshold', function () {
+    config()->set('vigilance.tracing.n_plus_one_threshold', 10);
+
+    $tracer = app(Tracer::class);
+    $tracer->start('request', 'GET /ok');
+    $t = microtime(true);
+    for ($i = 0; $i < 3; $i++) {
+        $tracer->span('query', 'select 1', $t, $t + 0.001);
+    }
+    $tracer->finish('ok');
+
+    app(Apm::class)->ingest();
+
+    expect(collect(app(Storage::class)->aggregate('n_plus_one', ['count'], CarbonInterval::hour())))->toBeEmpty();
+});


### PR DESCRIPTION
A broad, tested pass closing the gaps identified across the observability surface. Each item was verified against the real code before implementing; several claimed gaps turned out to already exist and were skipped.

## Delivered

**Error tracking (§5)**
- **Breadcrumbs** — bounded per-unit-of-work trail (`Vigilance::breadcrumb()` + automatic log capture), attached to issues, cleared at request/job boundaries, shown on the issue page and via MCP.
- **Manual issue merge** — move occurrences/runs to a canonical group, hide the source, redirect future occurrences of its signature (issue page + `merge-issues` tool).
- **User-feedback widget endpoint** — opt-in `POST {path}/feedback` tying a user complaint to their trace; `feedback` MCP tool.

**Tracing (§4)**
- **Distributed propagation** — W3C `traceparent` in (continue upstream) / out (outgoing HTTP), and across the **queue boundary** (job links to what dispatched it). Parent stored in trace attributes.

**Alerting (§6, §1, §3)**
- **Maintenance windows** — suppress notifications during planned maintenance (`vigilance:maintenance`, config windows, `maintenance` MCP tool).
- **Long-running-job detection** — alert on jobs stuck in "running" past a threshold.
- **N+1 first-class** — promoted from a per-trace attribute to an aggregatable APM signal + an opt-in alert rule.

**Metrics & capture (§10, §1, §13)**
- **Richer custom metrics** — `histogram()` / `timing()` distributions (p50/p95/p99) and `decrement()`.
- **Job capability tags** — `unique` / `encrypted` surfaced on runs.
- **Retry lineage** — `retry_of` is now actually set on a manually retried run.

**MCP parity (§9)**
- New tools: `routes`, `workload`, `record-deploy`, `assign-issue`, `maintenance`, `merge-issues`, `feedback` (+ the read tools now report control/paused state).

## Verified already-present (skipped)
log↔trace correlation (§8); Discord/Teams channels + `alertSink` custom-channel seam (§6); first-class batch entity with progress/cancel/retry via `BatchRepository` (§2); `IssueTool`/`TraceTool` already expose context/attributes.

## Deferred (with reason)
Continuous profiling & DOM session replay (need extra infrastructure); OTLP trace export (follow-up on the existing `Ingest`/`TraceStorage` seam); slow-cache recorder (cache events carry no duration); custom-metric dimensional tags; job chain lineage (Laravel models no shared chain id); deploy markers overlaid on charts (UI-only). Storage percentiles/aggregation remain sqlite/mysql/pgsql.

## Quality
Each feature has unit/Livewire/MCP/HTTP tests. Full suite **366 passed**; PHPStan clean (old + new Larastan); Pint clean; CSS build a no-op (no new utility classes). New config is off-by-default where it changes behaviour. New migrations: `merged_into` on failure groups, `vigilance_user_feedback`.

Not merged — parking for discussion of the next item.