### PR TITLE
N+1 incidents pinpoint the exact query and code line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **N+1 incidents now point at the exact query and the exact line.** Query spans
+  capture the application frame (`file:line`) that ran them, so a detected N+1
+  carries the repeated SQL *and* the offending code location — surfaced on the
+  trace page, in the promoted `n_plus_one` APM signal, and in the alert/incident
+  message itself. No more hunting through the trace to find which query, from
+  where. A new `Vigilance\Support\CodeLocation` helper resolves the nearest app
+  frame (skipping vendor and Vigilance's own frames).
+
 ## [0.8.0] - 2026-07-23
 
 A broad gap-closing pass across the observability surface (error tracking,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-23
+
 ### Added
 - **N+1 incidents now point at the exact query and the exact line.** Query spans
   capture the application frame (`file:line`) that ran them, so a detected N+1

--- a/resources/views/pages/trace-detail.blade.php
+++ b/resources/views/pages/trace-detail.blade.php
@@ -85,7 +85,10 @@
         <div class="v-card v-card--pad text-xs" role="status" style="border-color: var(--v-warn); background: var(--v-warn-bg); color: var(--v-warn);">
             <span class="font-semibold">Possible N+1 query.</span>
             The same query ran <span class="font-semibold">{{ $nPlusOne['count'] }}×</span> in this trace:
-            <code class="mt-1 block truncate font-mono">{{ $nPlusOne['sql'] }}</code>
+            <code class="mt-1 block break-all font-mono">{{ $nPlusOne['sql'] }}</code>
+            @if (! empty($nPlusOne['caller']))
+                <div class="mt-1">at <code class="font-mono font-semibold">{{ $nPlusOne['caller'] }}</code></div>
+            @endif
         </div>
     @endif
 

--- a/src/Notifications/Rules/NPlusOneRule.php
+++ b/src/Notifications/Rules/NPlusOneRule.php
@@ -34,14 +34,21 @@ class NPlusOneRule implements AlertRule
                 continue;
             }
 
-            $name = (string) $row->key;
+            // The key encodes the route/job, the exact SQL and the app line.
+            $decoded = json_decode((string) $row->key, true);
+            $name = is_array($decoded) ? (string) ($decoded['name'] ?? $row->key) : (string) $row->key;
+            $sql = is_array($decoded) ? (string) ($decoded['sql'] ?? '') : '';
+            $caller = is_array($decoded) ? ($decoded['caller'] ?? null) : null;
             $worst = (int) $row->max;
 
+            $detail = $sql !== '' ? " Query: {$sql}" : '';
+            $detail .= $caller ? " (at {$caller})" : '';
+
             yield new Alert(
-                key: 'n_plus_one:'.$name,
+                key: 'n_plus_one:'.$name.'|'.($caller ?? $sql),
                 title: 'N+1 query pattern',
-                message: "N+1 queries detected on [{$name}] — seen {$occurrences} time(s) in the last {$window}, "
-                    ."worst trace repeated a query {$worst} times.",
+                message: "N+1 queries on [{$name}] — a query ran {$worst} times in one request/job, "
+                    ."seen {$occurrences} time(s) in the last {$window}.{$detail}",
                 level: 'warning',
             );
         }

--- a/src/Support/CodeLocation.php
+++ b/src/Support/CodeLocation.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Vigilance\Support;
+
+/**
+ * Resolves the first application (non-vendor) frame that led to a call — used to
+ * point a query span (and the N+1 signal built from it) at the exact line of app
+ * code that ran the query, so you don't have to hunt for it.
+ */
+class CodeLocation
+{
+    /**
+     * The nearest application frame as "path:line" (relative to the app root),
+     * or null when the whole stack is framework/vendor code. Args are ignored
+     * and the walk is bounded, so it's cheap enough for a sampled trace.
+     */
+    public static function caller(int $limit = 30): ?string
+    {
+        // The Vigilance package's own directory, so its frames are skipped even
+        // when it isn't installed under vendor/ (a symlinked/path-repo install).
+        $packageDir = \dirname(__DIR__, 2).DIRECTORY_SEPARATOR;
+
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit) as $frame) {
+            $file = $frame['file'] ?? null;
+
+            if (! is_string($file) || $file === '') {
+                continue;
+            }
+
+            // Skip framework/dependency frames, Vigilance's own frames (by path or
+            // namespace), and keep walking until we reach application code.
+            if (str_contains($file, DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR)
+                || str_starts_with($file, $packageDir)
+                || str_starts_with((string) ($frame['class'] ?? ''), 'Vigilance\\')) {
+                continue;
+            }
+
+            return static::relative($file).':'.($frame['line'] ?? '?');
+        }
+
+        return null;
+    }
+
+    protected static function relative(string $file): string
+    {
+        $base = function_exists('base_path') ? base_path() : '';
+
+        return $base !== '' ? str_replace($base.DIRECTORY_SEPARATOR, '', $file) : $file;
+    }
+}

--- a/src/Tracing/Tracer.php
+++ b/src/Tracing/Tracer.php
@@ -252,11 +252,19 @@ class Tracer
             if ($nPlusOne = $this->detectNPlusOne($trace['spans'])) {
                 $attributes['n_plus_one'] = $nPlusOne;
 
-                // Promote N+1 to a first-class, aggregatable APM signal (keyed by
-                // the route/job name) so it can be counted and alerted on, not
-                // only spotted one trace at a time.
+                // Promote N+1 to a first-class, aggregatable APM signal so it can
+                // be counted and alerted on, not only spotted one trace at a time.
+                // The key carries the route, the exact repeated SQL and the app
+                // line, so the incident points straight at the offending query and
+                // code — no digging through the trace.
+                $key = (string) json_encode([
+                    'name' => (string) $trace['name'],
+                    'sql' => mb_substr((string) $nPlusOne['sql'], 0, 500),
+                    'caller' => $nPlusOne['caller'] ?? null,
+                ], JSON_UNESCAPED_SLASHES);
+
                 $this->rescue(fn () => $this->app->make(Apm::class)
-                    ->record('n_plus_one', (string) $trace['name'], (int) $nPlusOne['count'])
+                    ->record('n_plus_one', $key, (int) $nPlusOne['count'])
                     ->count()->max());
             }
 
@@ -331,7 +339,7 @@ class Tracer
      * repeated at least the configured number of times in one trace.
      *
      * @param  list<array<string, mixed>>  $spans
-     * @return array{sql: string, count: int}|null
+     * @return array{sql: string, count: int, caller?: ?string}|null
      */
     protected function detectNPlusOne(array $spans): ?array
     {
@@ -342,10 +350,13 @@ class Tracer
         }
 
         $counts = [];
+        $callers = [];
         foreach ($spans as $span) {
             if (($span['type'] ?? null) === 'query') {
                 $sql = (string) ($span['label'] ?? '');
                 $counts[$sql] = ($counts[$sql] ?? 0) + 1;
+                // Remember the app line the repeated query came from.
+                $callers[$sql] ??= $span['attributes']['caller'] ?? null;
             }
         }
 
@@ -362,7 +373,9 @@ class Tracer
             }
         }
 
-        return $max >= $threshold ? ['sql' => $sql, 'count' => $max] : null;
+        return $max >= $threshold
+            ? array_filter(['sql' => $sql, 'count' => $max, 'caller' => $callers[$sql] ?? null], fn ($v) => $v !== null)
+            : null;
     }
 
     protected function truncate(string $value): string

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -19,7 +19,7 @@ use Vigilance\Support\Defaults;
  */
 class Vigilance
 {
-    public static string $version = '0.8.0';
+    public static string $version = '0.8.1';
 
     /** Cache-busting token for the bundled stylesheet, derived from its contents. */
     protected static ?string $assetVersion = null;

--- a/src/VigilanceServiceProvider.php
+++ b/src/VigilanceServiceProvider.php
@@ -99,6 +99,7 @@ use Vigilance\Mcp\VigilanceServer;
 use Vigilance\Storage\DatabaseMetricsRepository;
 use Vigilance\Storage\DatabaseRunRepository;
 use Vigilance\Support\Breadcrumbs;
+use Vigilance\Support\CodeLocation;
 use Vigilance\Tracing\Contracts\TraceStorage;
 use Vigilance\Tracing\Middleware\TraceRequests;
 use Vigilance\Tracing\Sampling\Sampler;
@@ -464,9 +465,12 @@ class VigilanceServiceProvider extends ServiceProvider
         if (config('vigilance.tracing.spans.queries', true)) {
             $events->listen(QueryExecuted::class, function ($e) use ($tracer) {
                 if ($tracer->sampling()) {
-                    $tracer->rescue(fn () => $tracer->spanForDuration('query', $e->sql, (float) $e->time, [
+                    $tracer->rescue(fn () => $tracer->spanForDuration('query', $e->sql, (float) $e->time, array_filter([
                         'connection' => $e->connectionName,
-                    ]));
+                        // The app line that ran this query — so an N+1 points
+                        // straight at the offending code.
+                        'caller' => CodeLocation::caller(),
+                    ], fn ($v) => $v !== null)));
                 }
             });
         }

--- a/tests/Feature/CodeLocationTest.php
+++ b/tests/Feature/CodeLocationTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Vigilance\Support\CodeLocation;
+
+it('never resolves to a Vigilance-internal or vendor frame', function () {
+    // In the package's own test suite every frame lives under the package
+    // directory or vendor, so caller() correctly resolves to no application
+    // frame (null) rather than pointing at Vigilance's own internals — the exact
+    // regression guard for the N+1 "caller" location. The positive path (a real
+    // app frame → "relative/path.php:line") is covered end-to-end against a live
+    // Laravel app.
+    expect(CodeLocation::caller())->toBeNull();
+});

--- a/tests/Feature/NPlusOneRuleTest.php
+++ b/tests/Feature/NPlusOneRuleTest.php
@@ -14,22 +14,32 @@ beforeEach(function () {
     config()->set('vigilance.alerts.rules.n_plus_one', ['enabled' => true, 'min_occurrences' => 2, 'window' => '1h']);
 });
 
-it('alerts on recurring N+1 patterns', function () {
-    app(Apm::class)->record('n_plus_one', 'GET /list', 10)->count()->max();
-    app(Apm::class)->record('n_plus_one', 'GET /list', 14)->count()->max();
+function recordNPlusOne(string $name, string $sql, ?string $caller, int $count): void
+{
+    $key = (string) json_encode(['name' => $name, 'sql' => $sql, 'caller' => $caller]);
+    app(Apm::class)->record('n_plus_one', $key, $count)->count()->max();
+}
+
+it('alerts on recurring N+1 patterns and details the SQL and code line', function () {
+    recordNPlusOne('GET /list', 'select * from items where order_id = ?', 'app/Http/Controllers/OrderController.php:42', 10);
+    recordNPlusOne('GET /list', 'select * from items where order_id = ?', 'app/Http/Controllers/OrderController.php:42', 14);
     app(Apm::class)->ingest();
 
-    $captured = [];
-    Vigilance::alertUsing(function ($a) use (&$captured) {
-        $captured[] = $a->key;
+    $messages = [];
+    Vigilance::alertUsing(function ($a) use (&$messages) {
+        $messages[] = $a->message;
     });
 
-    expect(app(AlertManager::class)->check())->toBe(1)
-        ->and($captured)->toContain('n_plus_one:GET /list');
+    expect(app(AlertManager::class)->check())->toBe(1);
+
+    expect($messages[0])->toContain('GET /list')
+        ->toContain('select * from items where order_id = ?')
+        ->toContain('app/Http/Controllers/OrderController.php:42')
+        ->toContain('14 times');
 });
 
 it('stays quiet below the minimum occurrences', function () {
-    app(Apm::class)->record('n_plus_one', 'GET /list', 10)->count()->max();
+    recordNPlusOne('GET /list', 'select 1', null, 10);
     app(Apm::class)->ingest();
 
     expect(app(AlertManager::class)->check())->toBe(0);

--- a/tests/Tracing/NPlusOneSignalTest.php
+++ b/tests/Tracing/NPlusOneSignalTest.php
@@ -8,7 +8,7 @@ use Vigilance\Tracing\Tracer;
 
 uses(RefreshDatabase::class);
 
-it('promotes a detected N+1 to an aggregatable APM signal', function () {
+it('promotes a detected N+1 to an APM signal carrying the SQL and code location', function () {
     config()->set('vigilance.tracing.n_plus_one_threshold', 3);
 
     $tracer = app(Tracer::class);
@@ -16,17 +16,24 @@ it('promotes a detected N+1 to an aggregatable APM signal', function () {
 
     $t = microtime(true);
     for ($i = 0; $i < 4; $i++) {
-        $tracer->span('query', 'select * from users where id = ?', $t, $t + 0.001);
+        $tracer->span('query', 'select * from users where id = ?', $t, $t + 0.001, [
+            'caller' => 'app/Http/Controllers/OrderController.php:42',
+        ]);
     }
     $tracer->finish('ok');
 
     app(Apm::class)->ingest();
 
-    $row = collect(app(Storage::class)->aggregate('n_plus_one', ['count', 'max'], CarbonInterval::hour()))
-        ->firstWhere('key', 'GET /list');
+    $row = app(Storage::class)->aggregate('n_plus_one', ['count', 'max'], CarbonInterval::hour())->first();
 
     expect($row)->not->toBeNull()
         ->and((int) $row->max)->toBe(4);
+
+    // The key encodes route + exact SQL + the app line so the incident is actionable.
+    $decoded = json_decode((string) $row->key, true);
+    expect($decoded['name'])->toBe('GET /list')
+        ->and($decoded['sql'])->toBe('select * from users where id = ?')
+        ->and($decoded['caller'])->toBe('app/Http/Controllers/OrderController.php:42');
 });
 
 it('does not record an N+1 signal below the threshold', function () {
@@ -42,5 +49,5 @@ it('does not record an N+1 signal below the threshold', function () {
 
     app(Apm::class)->ingest();
 
-    expect(collect(app(Storage::class)->aggregate('n_plus_one', ['count'], CarbonInterval::hour())))->toBeEmpty();
+    expect(app(Storage::class)->aggregate('n_plus_one', ['count'], CarbonInterval::hour()))->toBeEmpty();
 });


### PR DESCRIPTION
## Problem
A reported N+1 only carried the route and a repeat count. To act on it you still had to open the trace, eyeball each query to find the repeated one, and grep the codebase for where it ran.

## What changed
- **Query spans capture the app frame** (`file:line`) that issued them — new `Vigilance\Support\CodeLocation` helper that walks past `vendor/` **and** Vigilance's own frames (robust to symlinked / path-repo installs, verified against a real app).
- **`detectNPlusOne`** now carries the repeated SQL and that caller location.
- **The promoted `n_plus_one` APM signal** keys on route + SQL + caller (same shape as the route-performance keys), so the **`NPlusOneRule` alert/incident message spells out the exact query and the exact line**.
- **The trace page** shows the offending line under the N+1 banner.

Example incident message:
> N+1 queries on [GET /orders] — a query ran 12 times in one request/job, seen 3 time(s) in the last 1h. Query: `select * from "items" where "order_id" = ?` (at app/Http/Controllers/OrderController.php:42)

## Verified
Against a live Laravel 13 app: `/nplus` (12 identical queries) → the incident and trace both show the SQL and `routes/web.php:8`. Full suite 370 green; PHPStan clean; Pint clean.

Follow-up to v0.8.0.