### PR TITLE
Aggregate alerts name the culprit, not just a count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-07-23
+
+### Added
+- **Aggregate alerts now name the culprit, not just a count.** The
+  failure-rate, exception-spike and slow-request-rate alerts spell out the worst
+  offenders inline: the top failing jobs/commands with their exception, the top
+  exception classes with their `file:line`, and the slowest routes with their max
+  latency — so the incident is actionable without opening a dashboard. The
+  long-running-job alert now includes the run id.
+
 ## [0.8.1] - 2026-07-23
 
 ### Added

--- a/src/Notifications/Rules/ErrorRateRule.php
+++ b/src/Notifications/Rules/ErrorRateRule.php
@@ -39,12 +39,30 @@ class ErrorRateRule implements AlertRule
             return;
         }
 
+        // Name the jobs/commands failing the most (with their exception) so the
+        // alert points at the culprit, not just a percentage.
+        $top = Run::query()
+            ->toBase()
+            ->where('created_at', '>=', $since)
+            ->where('status', RunStatus::Failed->value)
+            ->selectRaw('name, exception_class, count(*) as c')
+            ->groupBy('name', 'exception_class')
+            ->orderByDesc('c')
+            ->limit(3)
+            ->get()
+            ->map(fn ($r) => ((string) ($r->name ?? '') ?: 'unknown')
+                .($r->exception_class ? ' ('.class_basename((string) $r->exception_class).')' : '')
+                .' ×'.(int) $r->c)
+            ->all();
+
+        $detail = $top !== [] ? ' Top: '.implode('; ', $top).'.' : '';
+
         // The throttle key includes the rounded percent bucket so a worsening
         // incident can re-alert without spamming on every tick.
         yield new Alert(
             key: 'error_rate',
             title: 'Elevated failure rate',
-            message: "Failure rate is {$percent}% over the last hour ({$failed}/{$total} runs failed).",
+            message: "Failure rate is {$percent}% over the last hour ({$failed}/{$total} runs failed).{$detail}",
             level: 'critical',
         );
     }

--- a/src/Notifications/Rules/ExceptionSpikeRule.php
+++ b/src/Notifications/Rules/ExceptionSpikeRule.php
@@ -29,10 +29,24 @@ class ExceptionSpikeRule implements AlertRule
             return;
         }
 
+        // Name the worst offenders (class @ location × count) so the alert is
+        // actionable without opening the exceptions page.
+        $top = [];
+        foreach ($this->storage->aggregate('exception', ['count'], CarbonInterval::hour(), orderBy: 'count', limit: 3) as $row) {
+            $decoded = json_decode((string) $row->key, true);
+            if (is_array($decoded)) {
+                $top[] = ($decoded['class'] ?? 'Exception')
+                    .(($decoded['location'] ?? null) ? ' @ '.$decoded['location'] : '')
+                    .' ('.(int) $row->count.'×)';
+            }
+        }
+
+        $detail = $top !== [] ? ' Top: '.implode('; ', $top).'.' : '';
+
         yield new Alert(
             key: 'exception_spike',
             title: 'Exception spike',
-            message: "{$count} exceptions reported in the last hour (threshold {$threshold}).",
+            message: "{$count} exceptions reported in the last hour (threshold {$threshold}).{$detail}",
             level: 'critical',
         );
     }

--- a/src/Notifications/Rules/LongRunningJobRule.php
+++ b/src/Notifications/Rules/LongRunningJobRule.php
@@ -43,7 +43,7 @@ class LongRunningJobRule implements AlertRule
             yield new Alert(
                 key: 'long_running_job:'.$run->id,
                 title: 'Long-running job',
-                message: "Job [{$run->name}] has been running for {$seconds}s"
+                message: "Job [{$run->name}] (run #{$run->id}) has been running for {$seconds}s"
                     .($where !== '' ? " on [{$where}]" : '')
                     .' — it may be stuck or runaway.',
                 level: 'warning',

--- a/src/Notifications/Rules/SlowRequestRateRule.php
+++ b/src/Notifications/Rules/SlowRequestRateRule.php
@@ -29,10 +29,21 @@ class SlowRequestRateRule implements AlertRule
             return;
         }
 
+        // Name the slowest routes (method path × count, worst ms) so you know
+        // where to look.
+        $top = [];
+        foreach ($this->storage->aggregate('slow_request', ['count', 'max'], CarbonInterval::hour(), orderBy: 'count', limit: 3) as $row) {
+            $decoded = json_decode((string) $row->key, true);
+            $route = is_array($decoded) ? trim(($decoded[0] ?? '').' '.($decoded[1] ?? '')) : (string) $row->key;
+            $top[] = $route.' ('.(int) $row->count.'×, max '.(int) $row->max.'ms)';
+        }
+
+        $detail = $top !== [] ? ' Slowest: '.implode('; ', $top).'.' : '';
+
         yield new Alert(
             key: 'slow_request_rate',
             title: 'Many slow requests',
-            message: "{$count} slow requests in the last hour (threshold {$threshold}).",
+            message: "{$count} slow requests in the last hour (threshold {$threshold}).{$detail}",
             level: 'warning',
         );
     }

--- a/src/Vigilance.php
+++ b/src/Vigilance.php
@@ -19,7 +19,7 @@ use Vigilance\Support\Defaults;
  */
 class Vigilance
 {
-    public static string $version = '0.8.1';
+    public static string $version = '0.8.2';
 
     /** Cache-busting token for the bundled stylesheet, derived from its contents. */
     protected static ?string $assetVersion = null;

--- a/tests/Feature/AlertDetailTest.php
+++ b/tests/Feature/AlertDetailTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Vigilance\Apm\Apm;
+use Vigilance\Enums\RunStatus;
+use Vigilance\Enums\RunType;
+use Vigilance\Models\Run;
+use Vigilance\Notifications\Rules\ErrorRateRule;
+use Vigilance\Notifications\Rules\ExceptionSpikeRule;
+use Vigilance\Notifications\Rules\SlowRequestRateRule;
+
+uses(RefreshDatabase::class);
+
+function failedRun(string $name, ?string $exceptionClass): void
+{
+    Run::query()->create([
+        'uuid' => (string) Str::uuid(),
+        'type' => RunType::Job->value,
+        'name' => $name,
+        'status' => RunStatus::Failed->value,
+        'exception_class' => $exceptionClass,
+    ]);
+}
+
+it('error-rate alert names the top failing jobs and their exception', function () {
+    config()->set('vigilance.alerts.rules.error_rate', ['enabled' => true, 'min_runs' => 1, 'percent' => 1]);
+
+    failedRun('App\\Jobs\\OrderJob', 'RuntimeException');
+    failedRun('App\\Jobs\\OrderJob', 'RuntimeException');
+    failedRun('App\\Jobs\\EmailJob', 'Symfony\\Component\\Mailer\\Exception\\TransportException');
+
+    $msg = iterator_to_array(app(ErrorRateRule::class)->evaluate())[0]->message;
+
+    expect($msg)->toContain('App\\Jobs\\OrderJob (RuntimeException) ×2')
+        ->toContain('App\\Jobs\\EmailJob (TransportException) ×1');
+});
+
+it('exception-spike alert names the top exception class and code location', function () {
+    config()->set('vigilance.alerts.rules.exception_spike', ['enabled' => true, 'count' => 1]);
+
+    $apm = app(Apm::class);
+    foreach ([['RuntimeException', 'app/Services/Billing.php:88'], ['RuntimeException', 'app/Services/Billing.php:88'], ['TypeError', 'app/Http/X.php:12']] as [$class, $loc]) {
+        $apm->record('exception', (string) json_encode(['class' => $class, 'location' => $loc]), time())->max()->count();
+    }
+    $apm->ingest();
+
+    $msg = iterator_to_array(app(ExceptionSpikeRule::class)->evaluate())[0]->message;
+
+    expect($msg)->toContain('RuntimeException @ app/Services/Billing.php:88 (2×)')
+        ->toContain('TypeError @ app/Http/X.php:12 (1×)');
+});
+
+it('slow-request-rate alert names the slowest routes', function () {
+    config()->set('vigilance.alerts.rules.slow_request_rate', ['enabled' => true, 'count' => 1]);
+
+    $apm = app(Apm::class);
+    $apm->record('slow_request', (string) json_encode(['GET', '/orders']), 2100)->max()->count();
+    $apm->record('slow_request', (string) json_encode(['GET', '/orders']), 1800)->max()->count();
+    $apm->record('slow_request', (string) json_encode(['POST', '/checkout']), 1500)->max()->count();
+    $apm->ingest();
+
+    $msg = iterator_to_array(app(SlowRequestRateRule::class)->evaluate())[0]->message;
+
+    expect($msg)->toContain('GET /orders')
+        ->toContain('max 2100ms');
+});


### PR DESCRIPTION
## Motivation
Following the N+1 fix, I audited **every** alert rule for actionability against a real Laravel app. Most already named their target (anomaly → metric+σ, SLO burn → SLO, release health → release, scheduled-task/new/regressed-issue → the specific item). But three "aggregate count" rules only said *something* was wrong, not *what* — you had to open the dashboard and dig.

## What changed
- **error-rate** → names the top failing jobs/commands **with their exception**:
  > Failure rate is 50% (5/10 runs failed). Top: App\Jobs\OrderJob (RuntimeException) ×3; App\Jobs\EmailJob (TransportException) ×2.
- **exception-spike** → names the top exception classes **with `file:line`**:
  > 3 exceptions reported... Top: RuntimeException @ app/Services/Billing.php:88 (2×); TypeError @ app/Http/Controllers/X.php:12 (1×).
- **slow-request-rate** → names the **slowest routes** with count + max ms:
  > 42 slow requests... Slowest: GET /orders (18×, max 2100ms); ...
- **long-running-job** → includes the run id for direct navigation.

## Audit result (already actionable — left as-is)
- Slow queries & captured exceptions already carry the code location (`LocatesCode`).
- Anomaly / SLO-burn / release-health / scheduled-task / new-issue / issue-regression already name their target.
- Slow **outgoing** HTTP keys by URL (enough to identify the call); a code location there is a follow-up — the async Guzzle promise stack makes it unreliable to capture.

## Verified
Enriched messages confirmed against a live Laravel 13 app with fresh failing jobs + exception aggregates. Full suite 373 green; PHPStan clean; Pint clean.

Follow-up to v0.8.1.